### PR TITLE
Fix v7 component packaging regressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,9 @@ if(NOT TARGET_INSTALL_PACKAGE_DISABLE_INSTALL)
       "CMakeUtilities")
 
     install(
-      PROGRAMS
-        ${CMAKE_CURRENT_LIST_DIR}/cmake/build_minimal_container.sh
-        ${CMAKE_CURRENT_LIST_DIR}/cmake/collect_runtime_deps.sh
-        ${CMAKE_CURRENT_LIST_DIR}/cmake/container_to_quadlet.sh
+      PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/cmake/build_minimal_container.sh ${CMAKE_CURRENT_LIST_DIR}/cmake/collect_runtime_deps.sh ${CMAKE_CURRENT_LIST_DIR}/cmake/container_to_quadlet.sh
       DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
-      COMPONENT CMakeUtilities_Development)
+      COMPONENT Development)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(target_install_package VERSION 7.0.1)
+project(target_install_package VERSION 7.0.2)
 
 # ~~~
 # Project dependencies, these have been included directly in this project for

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,7 @@ if(NOT TARGET_INSTALL_PACKAGE_DISABLE_INSTALL)
       ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
       # Override include destination to put modules in the cmake dir
       INCLUDE_DESTINATION
-      ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
-      COMPONENT
-      "CMakeUtilities")
+      ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME})
 
     install(
       PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/cmake/build_minimal_container.sh ${CMAKE_CURRENT_LIST_DIR}/cmake/collect_runtime_deps.sh ${CMAKE_CURRENT_LIST_DIR}/cmake/container_to_quadlet.sh

--- a/CPack-Tutorial.md
+++ b/CPack-Tutorial.md
@@ -88,7 +88,9 @@ install(TARGETS mylib
             COMPONENT Runtime
             NAMELINK_COMPONENT Development
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}  # Windows DLLs
-    COMPONENT Runtime
+            COMPONENT Runtime
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}  # Windows import libs
+            COMPONENT Development
 )
 
 # Install static library (Development component)
@@ -191,13 +193,16 @@ set(CPACK_COMPONENT_DEVELOPMENT_DEPENDS Runtime)
 set(CPACK_COMPONENT_TOOLS_DESCRIPTION "Command-line tools and utilities")
 set(CPACK_COMPONENT_TOOLS_DISPLAY_NAME "Tools")
 
-# Set default components
-set(CPACK_COMPONENTS_DEFAULT Runtime)
+# Select Runtime by default in installers that support component metadata
+set(CPACK_COMPONENT_DEVELOPMENT_DISABLED TRUE)
+set(CPACK_COMPONENT_TOOLS_DISABLED TRUE)
 
 include(CPack)
 ```
 
 **Total Lines of CMake Code: ~85 lines** for packaging setup.
+
+`CPACK_COMPONENT_DEVELOPMENT_DEPENDS` is CPack component metadata. Raw `cmake --install --component` installs and component archives such as `TGZ`/`ZIP` do not follow it automatically. Native packages can enforce the relationship only through generator-specific settings, for example Debian component dependency settings for `DEB` or explicit `Requires` metadata for `RPM`.
 
 ---
 
@@ -289,7 +294,7 @@ target_sources(audio_engine PUBLIC FILE_SET HEADERS BASE_DIRS include FILES incl
 add_executable(game_editor tools/editor.cpp)
 target_link_libraries(game_editor PRIVATE graphics_engine audio_engine)
 
-# Install with dependencies automatically handled
+# Install targets and generate CMake package dependency calls
 target_install_package(graphics_engine 
     NAMESPACE GameEngine::
     EXPORT_NAME "GameEngine"
@@ -745,13 +750,15 @@ When multiple components are detected, packages are automatically split:
 # Linux output with components
 MyLib-1.0.0-Linux-Runtime.tar.gz      # Shared libraries
 MyLib-1.0.0-Linux-Development.tar.gz  # Headers + CMake configs + static libs
-MyLib-1.0.0-Linux-TOOLS.tar.gz        # Executables
+MyLib-1.0.0-Linux-Tools.tar.gz        # Executables
 
 # Corresponding DEB packages
 mylib-runtime_1.0.0_amd64.deb
 mylib-development_1.0.0_amd64.deb  
 mylib-tools_1.0.0_amd64.deb
 ```
+
+The split package output is a payload split. Extract archive components together when a development prefix needs shared-library targets, for example `Runtime` plus `Development`. Native package dependency enforcement is generator-specific; `export_cpack()` records component relationships but does not invent generic RPM `Requires` metadata.
 
 ---
 
@@ -763,12 +770,12 @@ Version 7 uses exact `COMPONENT_DEPENDENCIES` pairs. If one component has multip
 
 ```cmake
 # Before
-COMPONENT_DEPENDENCIES graphics "OpenGL REQUIRED;glfw3 REQUIRED"
+COMPONENT_DEPENDENCIES Graphics "OpenGL REQUIRED;glfw3 REQUIRED"
 
 # After
 COMPONENT_DEPENDENCIES
-    graphics "OpenGL REQUIRED"
-    graphics "glfw3 REQUIRED"
+    Graphics "OpenGL REQUIRED"
+    Graphics "glfw3 REQUIRED"
 ```
 
 Bare one-to-one pairs still work:

--- a/CPack-Tutorial.md
+++ b/CPack-Tutorial.md
@@ -209,8 +209,8 @@ Now, let's see the same functionality using our simplified approach:
 cmake_minimum_required(VERSION 3.25)
 project(MyProject VERSION 1.2.0 DESCRIPTION "My awesome library package")
 
-# Include target_install_package utilities
-include(target_install_package.cmake)  # or use FetchContent
+# Include target_install_package() and export_cpack()
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.1 CONFIG REQUIRED)
 
 # Create targets (same as before)
 add_library(mylib SHARED src/mylib.cpp)
@@ -523,7 +523,7 @@ GPG_KEYSERVER "keys.corp.internal"
 cmake_minimum_required(VERSION 3.25)
 project(SecureLibrary VERSION 2.1.0)
 
-include(target_install_package.cmake)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.1 CONFIG REQUIRED)
 
 # Create library targets
 add_library(secure_core SHARED src/core.cpp)

--- a/CPack-Tutorial.md
+++ b/CPack-Tutorial.md
@@ -210,7 +210,7 @@ cmake_minimum_required(VERSION 3.25)
 project(MyProject VERSION 1.2.0 DESCRIPTION "My awesome library package")
 
 # Include target_install_package() and export_cpack()
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.1 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.2 CONFIG REQUIRED)
 
 # Create targets (same as before)
 add_library(mylib SHARED src/mylib.cpp)
@@ -523,7 +523,7 @@ GPG_KEYSERVER "keys.corp.internal"
 cmake_minimum_required(VERSION 3.25)
 project(SecureLibrary VERSION 2.1.0)
 
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.1 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.2 CONFIG REQUIRED)
 
 # Create library targets
 add_library(secure_core SHARED src/core.cpp)

--- a/CPack-Tutorial.md
+++ b/CPack-Tutorial.md
@@ -85,6 +85,8 @@ include(GNUInstallDirs)
 # Install shared library (Runtime component)
 install(TARGETS mylib
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT Runtime
+            NAMELINK_COMPONENT Development
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}  # Windows DLLs
     COMPONENT Runtime
 )

--- a/README.md
+++ b/README.md
@@ -502,7 +502,9 @@ The component model uses predictable names:
 - **Without `COMPONENT`**: runtime files go to `Runtime`; SDK files go to `Development`.
 - **With `COMPONENT`**: runtime files go to the named component, such as `Core`; SDK files still go to `Development`.
 
-The `Development` component is intentionally shared by the export. It contains the SDK surface for `find_package()`: headers, static/import libraries, shared-library namelinks, CMake config/export files, include-on-find helpers, and CPS metadata by default. For shared libraries, a raw `cmake --install --component Development` install also needs the matching runtime components; package-manager installs receive those through CPack component dependencies.
+The `Development` component is intentionally shared by the export. It contains the SDK surface for `find_package()`: headers, static/import libraries, shared-library namelinks, CMake config/export files, include-on-find helpers, and CPS metadata by default. Static, interface, and header-only targets are SDK-only and do not create empty runtime components. For shared libraries, a raw `cmake --install --component Development` install also needs the matching runtime components. CPack records those component relationships as metadata; archive packages do not enforce them, and native package enforcement depends on generator-specific CPack settings.
+
+The detailed v7 component contract is captured in [Component Packaging Plan](docs/component-packaging-plan.md).
 
 ```cmake
 add_library(my_library SHARED)
@@ -697,22 +699,22 @@ target_install_package(engine_graphics
   NAMESPACE GameEngine::
   PUBLIC_DEPENDENCIES "fmt 11.1.4 REQUIRED"  # Always loaded
   COMPONENT_DEPENDENCIES
-    "graphics" "OpenGL 4.5 REQUIRED"  # Only when graphics requested
-    "graphics" "glfw3 3.3 REQUIRED"
+    "Graphics" "OpenGL 4.5 REQUIRED"  # Only when Graphics requested
+    "Graphics" "glfw3 3.3 REQUIRED"
 )
 
 target_install_package(engine_audio
   EXPORT_NAME "game_engine"
   NAMESPACE GameEngine::
   COMPONENT_DEPENDENCIES
-    "audio" "portaudio 19.7 REQUIRED"  # Only when audio requested
+    "Audio" "portaudio 19.7 REQUIRED"  # Only when Audio requested
 )
 
 target_install_package(engine_network
   EXPORT_NAME "game_engine" 
   NAMESPACE GameEngine::
   COMPONENT_DEPENDENCIES
-    "networking" "Boost 1.79 REQUIRED COMPONENTS system network"
+    "Networking" "Boost 1.79 REQUIRED COMPONENTS system network"
 )
 ```
 
@@ -722,13 +724,13 @@ target_install_package(engine_network
 find_package(game_engine REQUIRED)
 
 # Loads fmt + OpenGL + glfw3 
-find_package(game_engine REQUIRED COMPONENTS graphics)
+find_package(game_engine REQUIRED COMPONENTS Graphics)
 
 # Loads fmt + OpenGL + glfw3 + portaudio
-find_package(game_engine REQUIRED COMPONENTS graphics audio)
+find_package(game_engine REQUIRED COMPONENTS Graphics Audio)
 
 # Loads all dependencies
-find_package(game_engine REQUIRED COMPONENTS graphics audio networking)
+find_package(game_engine REQUIRED COMPONENTS Graphics Audio Networking)
 
 target_link_libraries(my_game PRIVATE 
   GameEngine::engine_graphics
@@ -737,8 +739,9 @@ target_link_libraries(my_game PRIVATE
 ```
 
 Note:
-- Pass exact component/dependency pairs. Repeat the component key for multiple dependencies, for example `COMPONENT_DEPENDENCIES graphics "OpenGL REQUIRED" graphics "glfw3 REQUIRED"`.
-- Bare shorthand is allowed for one dependency per component, for example `COMPONENT_DEPENDENCIES Core fmt Gui glfw`. Quote dependency expressions when they include options. Ambiguous bare lists such as `COMPONENT_DEPENDENCIES graphics OpenGL REQUIRED glfw3 REQUIRED` are rejected because CMake cannot distinguish dependency arguments from the next component key.
+- Pass exact component/dependency pairs. Repeat the component key for multiple dependencies, for example `COMPONENT_DEPENDENCIES Graphics "OpenGL REQUIRED" Graphics "glfw3 REQUIRED"`.
+- Component keys are case-sensitive CMake package component names. They may match install component names, but they only affect `find_package(... COMPONENTS ...)` dependency checks and found flags; they do not select installed files or hide exported targets.
+- Bare shorthand is allowed for one dependency per component, for example `COMPONENT_DEPENDENCIES Core fmt Gui glfw`. Quote dependency expressions when they include options. Ambiguous bare lists such as `COMPONENT_DEPENDENCIES Graphics OpenGL REQUIRED glfw3 REQUIRED` are rejected because CMake cannot distinguish dependency arguments from the next component key.
 - You may add `COMPONENT_DEPENDENCIES` across multiple `target_install_package()` calls that share the same `EXPORT_NAME`. Dependencies are merged and de-duplicated per component.
 - Optional `find_package(... OPTIONAL_COMPONENTS <name>)` requests probe that component's dependencies without making the whole package fail. Required component requests still use `find_dependency()` and fail when a required dependency is unavailable.
 
@@ -799,8 +802,8 @@ target_install_package(engine_graphics
   EXPORT_NAME "game_engine"
   NAMESPACE GameEngine::
   COMPONENT_DEPENDENCIES
-    "graphics" "OpenGL 4.5 REQUIRED"
-    "graphics" "glfw3 3.3 REQUIRED"
+    "Graphics" "OpenGL 4.5 REQUIRED"
+    "Graphics" "glfw3 3.3 REQUIRED"
   COMPONENT "Graphics"  # Runtime files: Graphics; SDK files: Development
 )
 
@@ -808,7 +811,7 @@ target_install_package(engine_physics
   EXPORT_NAME "game_engine"
   NAMESPACE GameEngine::
   COMPONENT_DEPENDENCIES
-    "physics" "Bullet3 3.24 REQUIRED"
+    "Physics" "Bullet3 3.24 REQUIRED"
   COMPONENT "Physics"  # Runtime files: Physics; SDK files: Development
 )
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ target_install_package(my_library
    - [CPack Package Generation](#cpack-package-generation)
    - [Mixing with Standard Install Commands](#mixing-with-standard-install-commands)
 4. [Component-Based Installation](#component-based-installation)
-   - [Component Prefix Pattern](#component-prefix-pattern)
+   - [Component Model](#component-model)
    - [Logical Component Grouping](#logical-component-grouping)
    - [Installing Specific Components](#installing-specific-components)
 5. [Multi-Target Exports](#multi-target-exports)
@@ -494,13 +494,15 @@ cmake --install . --component Documentation
 
 ## Component-Based Installation
 
-`target_install_package` supports logical component grouping using the **Component Prefix Pattern**, providing predictable component naming and clean installation control.
+`target_install_package` supports component-based installs with runtime components and one shared SDK component per export.
 
-### Component Prefix Pattern
+### Component Model
 
-The Component Prefix Pattern creates logical component groups with predictable naming:
-- **Without COMPONENT**: Creates `Runtime` and `Development` components (traditional)
-- **With COMPONENT**: Creates `{COMPONENT}` (runtime) and `{COMPONENT}_Development` (development) components
+The component model uses predictable names:
+- **Without `COMPONENT`**: runtime files go to `Runtime`; SDK files go to `Development`.
+- **With `COMPONENT`**: runtime files go to the named component, such as `Core`; SDK files still go to `Development`.
+
+The `Development` component is intentionally shared by the export. It contains the SDK surface for `find_package()`: headers, static/import libraries, shared-library namelinks, CMake config/export files, include-on-find helpers, and CPS metadata by default. For shared libraries, a raw `cmake --install --component Development` install also needs the matching runtime components; package-manager installs receive those through CPack component dependencies.
 
 ```cmake
 add_library(my_library SHARED)
@@ -511,10 +513,10 @@ target_sources(my_library PUBLIC
   FILES "include/my_library/api.h"
 )
 
-# Traditional: Creates Runtime and Development components
+# Default components: Runtime and Development
 target_install_package(my_library)
 
-# Logical grouping: Creates Core (runtime) and Core_Development (development) components  
+# Named runtime component: Core runtime files and Development SDK files
 target_install_package(my_library COMPONENT Core)
 ```
 
@@ -536,7 +538,7 @@ target_sources(engine_tools PUBLIC FILE_SET HEADERS BASE_DIRS include FILES incl
 target_install_package(engine_core
   EXPORT_NAME "GameEngine"
   NAMESPACE Engine::
-  COMPONENT Core)              # Creates: Core (runtime), Core_Development (development)
+  COMPONENT Core)              # Runtime files: Core; SDK files: Development
 
 target_install_package(engine_tools  
   EXPORT_NAME "GameEngine"
@@ -546,14 +548,13 @@ target_install_package(engine_tools
 target_install_package(level_editor
   EXPORT_NAME "GameEngine" 
   NAMESPACE Engine::
-  COMPONENT Tools)             # Creates: Tools (runtime), Tools_Development (development)
+  COMPONENT Tools)             # Runtime files: Tools; SDK files: Development
 ```
 
 **Result**: Single `GameEngine` package with logical component groups:
 - **Core**: `libengine_core.so` (runtime)
-- **Core_Development**: Headers from both targets + `libengine_tools.a` + shared CMake config files
 - **Tools**: `level_editor` executable (runtime)
-- **Tools_Development**: Headers for tools + development-only assets + shared CMake config files
+- **Development**: Headers from all exported libraries + static/import libraries + namelinks + shared CMake config files
 
 ### Installing Specific Components
 
@@ -561,29 +562,28 @@ target_install_package(level_editor
 # Install Core logical group - runtime only (deployment)
 cmake --install . --component Core
 
-# Install Core logical group - development files
-cmake --install . --component Core_Development  
+# Install SDK files for the export
+cmake --install . --component Development
 
 # Install Tools logical group - runtime only
 cmake --install . --component Tools
 
-# Shared CMake config files are installed with every development component
-cmake --install . --component Core_Development
-cmake --install . --component Tools_Development
+# Shared CMake config files are installed with the Development component
+cmake --install . --component Development
 
 # Install all runtime + development files (no component filtering)
 cmake --install .
 
 # Install everything for developers
 cmake --install . --component Core
-cmake --install . --component Core_Development
 cmake --install . --component Tools
-cmake --install . --component Tools_Development
+cmake --install . --component Development
 
 # Install everything
 cmake --install .
 ```
 
+Migrating from the older split-SDK naming is straightforward: replace `<Component>_Development` installs or package names with `Development`. Runtime component names from `COMPONENT`, such as `Core` and `Tools`, are unchanged.
 
 ## Multi-Target Exports
 
@@ -627,7 +627,7 @@ target_sources(myproject_cli PRIVATE src/cli.cpp)
 target_install_package(myproject_core
   EXPORT_NAME "myproject"
   NAMESPACE MyProject::
-  COMPONENT Core                             # Creates: Core (runtime), Core_Development (development)
+  COMPONENT Core                             # Runtime files: Core; SDK files: Development
   PUBLIC_DEPENDENCIES "fmt 11.1.4 REQUIRED"  # Shared by all targets
 )
 
@@ -641,14 +641,14 @@ target_install_package(myproject_utils
 target_install_package(myproject_cli
   EXPORT_NAME "myproject"
   NAMESPACE MyProject::
-  COMPONENT Tools                            # Creates: Tools (runtime), Tools_Development (development)
+  COMPONENT Tools                            # Runtime files: Tools; SDK files: Development
 )
 ```
 
 **Result**: Single package with logical component groups:
 - **Core**: Runtime component for Core targets; static-only Core targets may not add runtime files
-- **Core_Development**: Static libraries (`libmyproject_core.a`, `libmyproject_utils.a`) + headers from both Core libraries + shared CMake config files
 - **Tools**: CLI executable (`myproject_cli`) (runtime)
+- **Development**: Static libraries (`libmyproject_core.a`, `libmyproject_utils.a`) + headers from exported libraries + shared CMake config files
 
 **Consumer usage:**
 ```cmake
@@ -801,7 +801,7 @@ target_install_package(engine_graphics
   COMPONENT_DEPENDENCIES
     "graphics" "OpenGL 4.5 REQUIRED"
     "graphics" "glfw3 3.3 REQUIRED"
-  COMPONENT "Graphics"  # Creates Graphics and Graphics_Development
+  COMPONENT "Graphics"  # Runtime files: Graphics; SDK files: Development
 )
 
 target_install_package(engine_physics
@@ -809,7 +809,7 @@ target_install_package(engine_physics
   NAMESPACE GameEngine::
   COMPONENT_DEPENDENCIES
     "physics" "Bullet3 3.24 REQUIRED"
-  COMPONENT "Physics"  # Creates Physics and Physics_Development
+  COMPONENT "Physics"  # Runtime files: Physics; SDK files: Development
 )
 
 target_install_package(level_editor
@@ -839,16 +839,15 @@ cmake --install . --component Runtime
 cmake --install . --component Runtime
 cmake --install . --component Graphics
 
-# Full game development environment with all runtime components
+# Full game development environment with all runtime components and the SDK
 cmake --install . --component Runtime
 cmake --install . --component Graphics
 cmake --install . --component Physics
 cmake --install . --component Tools
-
-# Development files for Graphics and Physics
 cmake --install . --component Development
-cmake --install . --component Graphics_Development
-cmake --install . --component Physics_Development
+
+# Development files for the complete game_engine export
+cmake --install . --component Development
 
 # Install every component at once (no explicit selection)
 cmake --install .

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ include(FetchContent)
 FetchContent_Declare(
   target_install_package
   GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-  GIT_TAG v7.0.1
+  GIT_TAG v7.0.2
 )
 FetchContent_MakeAvailable(target_install_package)
 
@@ -200,7 +200,7 @@ if(${PROJECT_NAME}_INSTALL)
   FetchContent_Declare(
     target_install_package
     GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-    GIT_TAG v7.0.1
+    GIT_TAG v7.0.2
     # Optional arg to first try find_package locally before fetching, see manual installation
     # NOTE: This must be called last, with 0 to N args following FIND_PACKAGE_ARGS
     # FIND_PACKAGE_ARGS

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ target_install_package(level_editor
 - **Core**: `libengine_core.so` (runtime)
 - **Core_Development**: Headers from both targets + `libengine_tools.a` + shared CMake config files
 - **Tools**: `level_editor` executable (runtime)
-- **Tools_Development**: Headers for tools + development-only assets
+- **Tools_Development**: Headers for tools + development-only assets + shared CMake config files
 
 ### Installing Specific Components
 
@@ -567,8 +567,9 @@ cmake --install . --component Core_Development
 # Install Tools logical group - runtime only
 cmake --install . --component Tools
 
-# Shared CMake config files live with the first development component
+# Shared CMake config files are installed with every development component
 cmake --install . --component Core_Development
+cmake --install . --component Tools_Development
 
 # Install all runtime + development files (no component filtering)
 cmake --install .
@@ -739,6 +740,7 @@ Note:
 - Pass exact component/dependency pairs. Repeat the component key for multiple dependencies, for example `COMPONENT_DEPENDENCIES graphics "OpenGL REQUIRED" graphics "glfw3 REQUIRED"`.
 - Bare shorthand is allowed for one dependency per component, for example `COMPONENT_DEPENDENCIES Core fmt Gui glfw`. Quote dependency expressions when they include options. Ambiguous bare lists such as `COMPONENT_DEPENDENCIES graphics OpenGL REQUIRED glfw3 REQUIRED` are rejected because CMake cannot distinguish dependency arguments from the next component key.
 - You may add `COMPONENT_DEPENDENCIES` across multiple `target_install_package()` calls that share the same `EXPORT_NAME`. Dependencies are merged and de-duplicated per component.
+- Optional `find_package(... OPTIONAL_COMPONENTS <name>)` requests probe that component's dependencies without making the whole package fail. Required component requests still use `find_dependency()` and fail when a required dependency is unavailable.
 
 ### Game Engine with Modular Components
 

--- a/ci/cmd/cpack.sh
+++ b/ci/cmd/cpack.sh
@@ -181,7 +181,7 @@ run_basic() {
   (cd "${build_dir}" && \
     runtime_has_exe="$(tar -tzf MyLibrary-*-Runtime.tar.gz | grep -c 'bin/mytool' || true)" && \
     dev_has_headers="$(tar -tzf MyLibrary-*-Development.tar.gz | grep -c 'include/' || true)" && \
-    tools_has_exe="$(tar -tzf MyLibrary-*-TOOLS.tar.gz | grep -c 'bin/mytool' || true)" && \
+    tools_has_exe="$(tar -tzf MyLibrary-*-Tools.tar.gz | grep -c 'bin/mytool' || true)" && \
     [[ "${runtime_has_exe}" == "0" ]] || exit 1 && \
     [[ "${dev_has_headers}" != "0" ]] || exit 1 && \
     [[ "${tools_has_exe}" != "0" ]] || exit 1)
@@ -200,8 +200,8 @@ run_basic() {
     mkdir -p test-runtime test-dev test-tools-alone test-tools-with-deps && \
     (cd test-runtime && tar -xzf ../MyLibrary-*-Runtime.tar.gz) && \
     (cd test-dev && tar -xzf ../MyLibrary-*-Development.tar.gz) && \
-    (cd test-tools-alone && tar -xzf ../MyLibrary-*-TOOLS.tar.gz) && \
-    (cd test-tools-with-deps && tar -xzf ../MyLibrary-*-TOOLS.tar.gz && tar -xzf ../MyLibrary-*-Runtime.tar.gz))
+    (cd test-tools-alone && tar -xzf ../MyLibrary-*-Tools.tar.gz) && \
+    (cd test-tools-with-deps && tar -xzf ../MyLibrary-*-Tools.tar.gz && tar -xzf ../MyLibrary-*-Runtime.tar.gz))
 
   (cd "${build_dir}/test-runtime" && \
     if ci_is_windows; then
@@ -307,7 +307,7 @@ run_cross_platform() {
       else
         ci_warn "Development component package missing"
       fi
-      if ls *-TOOLS.tar.gz 1>/dev/null 2>&1; then
+      if ls *-Tools.tar.gz 1>/dev/null 2>&1; then
         ci_log "✓ Tools component package found"
       else
         ci_warn "Tools component package missing"

--- a/ci/cmd/cpack.sh
+++ b/ci/cmd/cpack.sh
@@ -272,10 +272,10 @@ run_components() {
   (cd "${build_dir}" && cpack --verbose)
 
   (cd "${build_dir}" && ls -la MediaLibrary-*.tar.gz MediaLibrary-*.deb 2>/dev/null || true)
-  if (cd "${build_dir}" && ls MediaLibrary-*-CORE.tar.gz 1>/dev/null 2>&1); then
-    ci_log "✓ Components example produced CORE group package"
+  if (cd "${build_dir}" && ls MediaLibrary-*-Core.tar.gz 1>/dev/null 2>&1); then
+    ci_log "✓ Components example produced Core component package"
   else
-    ci_die "Components example did not produce expected CORE group package"
+    ci_die "Components example did not produce expected Core component package"
   fi
 }
 

--- a/ci/cmd/main.sh
+++ b/ci/cmd/main.sh
@@ -154,7 +154,7 @@ fi
 
 ci_log "==> Component install smoke test"
 cmake --install "${build_dir}" \
-  --component CMakeUtilities_Development \
+  --component Development \
   --prefix "${install_dir}-components"
 if [[ -f "${install_dir}-components/share/cmake/target_install_package/target_install_package.cmake" ]]; then
   ci_log "✓ Component install OK"

--- a/docs/auto_finalization.md
+++ b/docs/auto_finalization.md
@@ -33,12 +33,11 @@ Notes:
 Interaction with CPack
 ----------------------
 
-- `export_cpack()` also uses deferred execution, and it expects all exports to be finalized by the time it runs.
-- When both utilities are used, the order is: prepare targets → finalize packages (auto/explicit) → configure CPack (auto).
+- `export_cpack()` also uses deferred execution and forces any registered, unfinalized exports to finalize before it reads auto-detected components.
+- When both utilities are used, the effective order is: prepare targets → finalize pending packages (explicit, auto, or CPack-forced) → configure CPack (auto).
 
 Troubleshooting
 ---------------
 
 - If an export appears incomplete, ensure all contributing targets were configured before the end of the top-level configure step, or call `finalize_package()` explicitly.
 - In superbuilds, the automatic finalization still runs at the superproject’s `CMAKE_SOURCE_DIR`, which is typically desirable due to global target scope.
-

--- a/docs/component-packaging-plan.md
+++ b/docs/component-packaging-plan.md
@@ -1,0 +1,60 @@
+# Component Packaging Plan
+
+This plan records the v7 component contract and the fixes needed to make the implementation match it.
+
+## Contract
+
+- `target_install_package(... COMPONENT <name>)` names runtime payload only.
+- SDK payload for an export installs to one shared `Development` component.
+- Runtime payload means executables, shared-library runtime files, Windows DLLs, and module-library runtime files.
+- Static libraries, interface libraries, and header-only targets are SDK-only unless another target registered through this wrapper puts runtime payload in the same component. Standalone manual install components need explicit `export_cpack(COMPONENTS ...)` inclusion.
+- Raw `cmake --install --component <name>` installs exactly that component and does not resolve dependencies.
+- Archive component packages are payload archives and do not enforce dependencies.
+- Native package-manager dependency behavior is generator-specific. `export_cpack()` should not promise generic DEB/RPM dependency solving unless it implements and tests the generator-specific metadata.
+- CMake package components are dependency gates/found flags, not target-visibility or install-payload selectors.
+- Separate `EXPORT_NAME`s are the escape hatch for independently installable SDK subsets.
+
+## Implementation Plan
+
+1. Make runtime component registration payload-aware.
+   - Register runtime components only for targets with runtime artifacts.
+   - Do not create empty runtime packages for static or interface targets.
+   - Keep `Development` registered for SDK/config payload.
+
+2. Derive CPack defaults from detected payload components.
+   - Validate explicit `DEFAULT_COMPONENTS` against `COMPONENTS`.
+   - If defaults are implicit, use detected runtime payload components.
+   - If no runtime payload component exists, default to `Development`.
+   - Express selected defaults using CPack's per-component `DISABLED` metadata; do not emit unsupported default-list variables.
+
+3. Make explicit single-component CPack filtering work.
+   - Treat explicit `COMPONENTS <one-component>` as a component-install request.
+   - This prevents `export_cpack(COMPONENTS Development)` from creating a full unfiltered archive.
+
+4. Add export alias validation.
+   - Fail before install generation if two targets in one export resolve to the same exported target name.
+
+5. Add regression tests.
+   - Static-only named component must produce `Development` only, not an empty runtime package.
+   - Explicit one-component `export_cpack(COMPONENTS Development)` must package only that component.
+   - Duplicate exported aliases must fail configure/finalize.
+   - Existing unified `Development` tests must remain green.
+
+6. Audit docs and examples.
+   - Distinguish raw component installs, archive extraction, and native package-manager installs.
+   - State that shared-library consumers need runtime components plus `Development` for raw installs.
+   - Do not claim generic RPM dependency generation.
+   - Keep DEB/RPM dependency mapping as a separate constrained follow-up unless implemented and tested.
+
+7. Validate and review.
+   - Run focused proof tests.
+   - Run the full CTest suite.
+   - Run example/package smoke tests where relevant.
+   - Run a final Codex review pass on the implemented plan before pushing.
+
+## Explicit Non-Goals For This Patch
+
+- Do not restore generated `<Component>_Development` components.
+- Do not duplicate shared-library runtime files into `Development`.
+- Do not implement a generic RPM `Requires` mapper without a stable package-name policy and tests.
+- Do not make `find_package(... COMPONENTS ...)` hide exported targets.

--- a/docs/default_install_dirs.md
+++ b/docs/default_install_dirs.md
@@ -58,9 +58,10 @@ Notes:
 | Development | Headers, import libs, static libs, shared-library namelinks, CMake configs, CPS metadata by default | Required for building |
 
 CMake config and export files are installed with the shared `Development` component for the export. When `COMPONENT <name>` is used, only runtime files move to `<name>`; headers, static/import libraries, shared-library namelinks, CMake metadata, include-on-find helpers, and CPS metadata by default stay in `Development`.
-When a single export contains several runtime components, `export_cpack()` makes `Development` depend on those runtime components so package-manager installs receive a complete importable target set.
+`export_cpack()` records dependencies from each development component to the runtime components registered by exports using that development component.
 Direct `cmake --install --component <name>` installs only the named component and does not follow CPack dependencies; run a full install or install `Development` plus the related runtime components when manually assembling a partial tree from a shared export.
-Static-only and interface-only targets do not contribute runtime payloads, so their named runtime component can be empty unless other runtime targets share that component.
+Component archives such as `TGZ` and `ZIP` are payload slices and do not install dependency archives automatically. Native package managers can enforce component dependencies only when the selected CPack generator is configured to translate that metadata, such as Debian component dependency settings for `DEB` or explicit `Requires` metadata for `RPM`.
+Static-only and interface-only targets do not contribute runtime payloads, so their named runtime component is not auto-registered unless other runtime targets share that component. Standalone manual `install(... COMPONENT <name>)` rules are not auto-discovered by `export_cpack()`; list those components explicitly with `export_cpack(COMPONENTS ...)` when they must appear in generated packages.
 
 CPS metadata is installed with `Development` by default.
 Set `CPS_COMPONENT` to place CPS metadata in a different install component.

--- a/docs/default_install_dirs.md
+++ b/docs/default_install_dirs.md
@@ -57,17 +57,18 @@ Notes:
 | Runtime | Executables, DLLs, shared libraries, shared-library SONAME links | Required at runtime |
 | Development | Headers, import libs, static libs, shared-library namelinks, CMake configs, CPS metadata by default | Required for building |
 
-CMake config and export files are installed with every development component for the export: `Development` by default, or each `<COMPONENT>_Development` component when component prefixes are used.
-When a single export contains several component groups, `export_cpack()` makes each development component depend on the other target components in that export so package-manager installs receive a complete importable target set.
-Direct `cmake --install --component <name>` installs only the named component; run a full install or install the related runtime/development components when manually assembling a partial tree from a shared export.
+CMake config and export files are installed with the shared `Development` component for the export. When `COMPONENT <name>` is used, only runtime files move to `<name>`; headers, static/import libraries, shared-library namelinks, CMake metadata, include-on-find helpers, and CPS metadata by default stay in `Development`.
+When a single export contains several runtime components, `export_cpack()` makes `Development` depend on those runtime components so package-manager installs receive a complete importable target set.
+Direct `cmake --install --component <name>` installs only the named component and does not follow CPack dependencies; run a full install or install `Development` plus the related runtime components when manually assembling a partial tree from a shared export.
+Static-only and interface-only targets do not contribute runtime payloads, so their named runtime component can be empty unless other runtime targets share that component.
 
-CPS metadata is installed with `Development` by default, or the first development component for the export when component prefixes are used.
+CPS metadata is installed with `Development` by default.
 Set `CPS_COMPONENT` to place CPS metadata in a different install component.
 SBOM metadata is different: `install(SBOM)` does not expose a `COMPONENT`
 option, so SBOM files are available in full installs and follow CMake's
 default non-component behavior rather than this wrapper's `Development`
 component routing. For example, `cmake --install <build-dir> --component
-<COMPONENT>_Development` does not install the SBOM.
+Development` does not install the SBOM.
 
 ## Additional Files
 

--- a/docs/default_install_dirs.md
+++ b/docs/default_install_dirs.md
@@ -54,10 +54,14 @@ Notes:
 
 | Component | Contains | Purpose |
 |-----------|----------|---------|
-| Runtime | Executables, DLLs, shared libraries | Required at runtime |
-| Development | Headers, import libs, static libs, CMake configs, CPS metadata by default | Required for building |
+| Runtime | Executables, DLLs, shared libraries, shared-library SONAME links | Required at runtime |
+| Development | Headers, import libs, static libs, shared-library namelinks, CMake configs, CPS metadata by default | Required for building |
 
-CPS metadata is installed with the same component as the CMake config files: `Development` by default, or the first development component for the export when component prefixes are used.
+CMake config and export files are installed with every development component for the export: `Development` by default, or each `<COMPONENT>_Development` component when component prefixes are used.
+When a single export contains several component groups, `export_cpack()` makes each development component depend on the other target components in that export so package-manager installs receive a complete importable target set.
+Direct `cmake --install --component <name>` installs only the named component; run a full install or install the related runtime/development components when manually assembling a partial tree from a shared export.
+
+CPS metadata is installed with `Development` by default, or the first development component for the export when component prefixes are used.
 Set `CPS_COMPONENT` to place CPS metadata in a different install component.
 SBOM metadata is different: `install(SBOM)` does not expose a `COMPONENT`
 option, so SBOM files are available in full installs and follow CMake's

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -34,7 +34,7 @@ target_install_package(math_utils
 - All `target_install_package(... SBOM ...)` calls sharing one `EXPORT_NAME` must agree on every non-empty SBOM option, including metadata inheritance mode: same project metadata, `SBOM_NO_PROJECT_METADATA`, or explicit fields only.
 - `SBOM_PROJECT` and `SBOM_NO_PROJECT_METADATA` are mutually exclusive in a single call and conflict if mixed for the same export.
 - `SBOM_FORMAT` is omitted by default so CMake uses its current SPDX 3.0.1 JSON-LD output.
-- `install(SBOM)` has no `COMPONENT` option. SBOM files therefore participate in full installs and CMake's own default non-component behavior rather than this wrapper's development component routing. A component install such as `cmake --install <build-dir> --component Sdk_Development` does not install the SBOM.
+- `install(SBOM)` has no `COMPONENT` option. SBOM files therefore participate in full installs and CMake's own default non-component behavior rather than this wrapper's development component routing. A component install such as `cmake --install <build-dir> --component Development` does not install the SBOM.
 - CMake cannot generate an SBOM for targets whose `LINK_LIBRARIES` or `INTERFACE_LINK_LIBRARIES` contain generator expressions unless those expressions are guarded by `$<LINK_ONLY:...>`.
 - CMake may emit a developer warning because SBOM generation is experimental. Use `-Wno-dev` if you want quieter configure output.
 - `SBOM_LICENSE` is package/project-level metadata. Per-target component licenses should be set with each target's `SPDX_LICENSE` property.

--- a/examples/README.md
+++ b/examples/README.md
@@ -132,8 +132,8 @@ cmake --install . --component Development
 
 # Install logical component groups (see components example)
 cmake --install . --component Core
-cmake --install . --component Core_Development
 cmake --install . --component Tools
+cmake --install . --component Development
 ```
 
 ## 📁 Installation Structure

--- a/examples/components-same-export/CMakeLists.txt
+++ b/examples/components-same-export/CMakeLists.txt
@@ -53,7 +53,7 @@ target_install_package(
   NAMESPACE
   Media::
   COMPONENT
-  "Core") # Creates Core + Core_Development
+  "Core") # Runtime files: Core; SDK files: Development
 
 target_install_package(
   media_dev_tools2
@@ -62,7 +62,7 @@ target_install_package(
   NAMESPACE
   Media::
   COMPONENT
-  "DevTools") # Creates DevTools + DevTools_Development
+  "DevTools") # Static-only target: SDK files in Development
 
 target_install_package(
   storage
@@ -71,7 +71,7 @@ target_install_package(
   NAMESPACE
   Media::
   COMPONENT
-  "Storage") # Creates Storage + Storage_Development
+  "Storage") # Runtime files: Storage; SDK files: Development
 
 target_install_package(
   asset_converter2
@@ -80,4 +80,4 @@ target_install_package(
   NAMESPACE
   Media::
   COMPONENT
-  "Tools") # Creates Tools + Tools_Development
+  "Tools") # Runtime files: Tools; SDK files: Development

--- a/examples/components-same-export/README.md
+++ b/examples/components-same-export/README.md
@@ -38,7 +38,7 @@ cmake --install . --component Tools
 cmake --install . --component Development
 ```
 
-The `Development` component installs SDK files for the shared `engine2` export, including CMake package metadata. When packaged through `export_cpack()`, `Development` depends on the runtime components in that export so package-manager installs produce a complete importable target set. For raw `cmake --install --component` usage, install `Development` plus the runtime components you need.
+The `Development` component installs SDK files for the shared `engine2` export, including CMake package metadata. When packaged through `export_cpack()`, `Development` records dependencies on the runtime components in that export. Raw `cmake --install --component` and component archives do not follow those dependencies automatically, so install or extract `Development` plus the runtime components you need. Native packages enforce the relationship only when their CPack generator is configured to translate component dependency metadata.
 
 ## Using the Installed Package
 

--- a/examples/components-same-export/README.md
+++ b/examples/components-same-export/README.md
@@ -39,6 +39,9 @@ cmake --install . --component Storage
 cmake --install . --component Storage_Development
 cmake --install . --component Tools
 ```
+
+Each development component installs the shared `engine2` CMake package metadata. When packaged through `export_cpack()`, development components for the same export depend on the other target components in that export so package-manager installs produce a complete importable target set.
+
 ## Using the Installed Package
 
 Create a consumer project:

--- a/examples/components-same-export/README.md
+++ b/examples/components-same-export/README.md
@@ -31,16 +31,14 @@ cmake --build .
 # Install all components
 cmake --install .
 
-# Or install specific components
+# Or install runtime components plus the SDK. DevTools is static-only, so its payload is in Development.
 cmake --install . --component Core
-cmake --install . --component Core_Development
-cmake --install . --component DevTools_Development
 cmake --install . --component Storage
-cmake --install . --component Storage_Development
 cmake --install . --component Tools
+cmake --install . --component Development
 ```
 
-Each development component installs the shared `engine2` CMake package metadata. When packaged through `export_cpack()`, development components for the same export depend on the other target components in that export so package-manager installs produce a complete importable target set.
+The `Development` component installs SDK files for the shared `engine2` export, including CMake package metadata. When packaged through `export_cpack()`, `Development` depends on the runtime components in that export so package-manager installs produce a complete importable target set. For raw `cmake --install --component` usage, install `Development` plus the runtime components you need.
 
 ## Using the Installed Package
 

--- a/examples/components/CMakeLists.txt
+++ b/examples/components/CMakeLists.txt
@@ -30,7 +30,7 @@ target_compile_features(media_dev_tools PUBLIC cxx_std_17)
 add_executable(asset_converter)
 target_sources(asset_converter PRIVATE src/asset_converter.cpp)
 
-# Install with component prefix grouping. All targets share EXPORT_NAME="MediaLib" to create a unified package.
+# Install with logical runtime components. All targets share EXPORT_NAME="MediaLib" to create a unified package and one Development SDK component.
 target_install_package(
   media_core
   EXPORT_NAME
@@ -38,7 +38,7 @@ target_install_package(
   NAMESPACE
   Media::
   COMPONENT
-  Core) # Creates: Core (runtime), Core_Development (development)
+  Core) # Runtime files: Core; SDK files: Development
 
 target_install_package(
   media_dev_tools
@@ -47,7 +47,7 @@ target_install_package(
   NAMESPACE
   Media::
   COMPONENT
-  Core) # Creates: Core (runtime), Core_Development (development) - same logical group as media_core
+  Core) # Same Core runtime group as media_core; SDK files: Development
 
 target_install_package(
   asset_converter
@@ -56,10 +56,9 @@ target_install_package(
   NAMESPACE
   Media::
   COMPONENT
-  Tools) # Creates: Tools (runtime), Tools_Development (development)
+  Tools) # Runtime files: Tools; SDK files: Development
 
-# Use enhanced export_cpack with auto-detection of logical groups Components will auto-detected as: Core, Core_Development, Tools, Tools_Development Logical groups will be auto-created: Core (contains
-# Core and Core_Development), Tools (contains Tools and Tools_Development) Component dependencies will be auto-set: *_Development depends on corresponding runtime component
+# export_cpack auto-detects Core, Tools, and Development. The Development component depends on the runtime components for package-manager installs.
 export_cpack(
   PACKAGE_NAME
   "MediaLibrary"

--- a/examples/components/CMakeLists.txt
+++ b/examples/components/CMakeLists.txt
@@ -58,7 +58,7 @@ target_install_package(
   COMPONENT
   Tools) # Runtime files: Tools; SDK files: Development
 
-# export_cpack auto-detects Core, Tools, and Development. The Development component depends on the runtime components for package-manager installs.
+# export_cpack auto-detects Core, Tools, and Development. The Development component records dependencies on runtime components.
 export_cpack(
   PACKAGE_NAME
   "MediaLibrary"

--- a/examples/components/README.md
+++ b/examples/components/README.md
@@ -1,99 +1,56 @@
-# Component Prefix Pattern Example
+# Component Installation Example
 
-This example demonstrates the **Component Prefix Pattern** for logical component grouping with shared exports and predictable naming.
+This example demonstrates logical runtime components with one shared SDK component for a single `MediaLib` export.
 
 ## Features Demonstrated
 
-- **Component Prefix Pattern**: `COMPONENT="Core"` creates `Core` (runtime), `Core_Development` (development)
-- **Logical Grouping**: Multiple targets share the same logical component group
-- **Shared Export**: All targets packaged under single `MediaLib` export
-- **Mixed Target Types**: Shared library, static library, and executable
-- **Selective Installation**: Install specific logical groups or individual components
+- **Runtime components**: `COMPONENT Core` installs runtime files into `Core`; `COMPONENT Tools` installs runtime files into `Tools`.
+- **Shared SDK component**: headers, static/import libraries, namelinks, and CMake package metadata install into `Development`.
+- **Shared export**: all targets are packaged under one `MediaLib` export.
+- **Mixed target types**: shared library, static library, and executable.
+- **Selective installation**: install runtime pieces separately, or install SDK files through one component.
 
 ## Architecture
 
 ```
-MediaLib Package (shared export with Component Prefix Pattern):
-├── Core             → libmedia_core.so (shared library runtime files) 
-├── Core_Development → headers + libmedia_dev_tools.a + MediaLib CMake config files
-├── Tools            → asset_converter (executable runtime)
-└── Tools_Development → MediaLib CMake config files
+MediaLib package:
+├── Core         - libmedia_core runtime files
+├── Tools        - asset_converter runtime executable
+└── Development  - headers, libmedia_dev_tools.a, namelinks, and MediaLib CMake config files
 ```
 
-The Component Prefix Pattern creates predictable component names: `{COMPONENT}` for runtime, `{COMPONENT}_Development` for development. Shared CMake config files are installed with each development component for the export, so both `Core_Development` and `Tools_Development` carry the package entry point.
+`COMPONENT` does not create a second SDK component. It only names runtime files. The `Development` component carries SDK files for the whole export. For shared-library consumers, install `Development` plus the runtime components, or use package-manager packages that honor the generated component dependencies.
 
 ## Building and Installing
 
-### Step 1: Configure and Build
+### Configure and Build
 
 ```bash
-# Create build directory
 mkdir build && cd build
-
-# Configure with install prefix set to build directory
 cmake .. -DCMAKE_INSTALL_PREFIX=./install -DPROJECT_LOG_COLORS=ON --log-level=DEBUG
-
-# Build all targets
 cmake --build .
 ```
 
-### Step 2: Component-Based Installation
-
-#### Install All Components
+### Component-Based Installation
 
 ```bash
-# Install everything - all logical groups
+# Install everything
 cmake --install .
-```
 
-#### Install Core Logical Group
-
-```bash
-# Install only Core runtime files (end-user deployment)
-cmake --install . --component Core
-
-# Install only Core development files (headers + static libs)  
-cmake --install . --component Core_Development
-
-# Install both Core runtime and development
-cmake --install . --component Core
-cmake --install . --component Core_Development
-```
-
-#### Install Tools Logical Group  
-
-```bash
-# Install only Tools runtime (executable)
-cmake --install . --component Tools
-
-# Tools_Development carries shared CMake package metadata for the export
-cmake --install . --component Tools_Development
-```
-
-#### Install CMake Configuration
-
-```bash
-# Install shared CMake config files (needed for find_package)
-cmake --install . --component Core_Development
-cmake --install . --component Tools_Development
-```
-
-#### Deployment Scenarios
-
-```bash
-# Minimal runtime deployment (libraries + tools)
+# Minimal runtime deployment
 cmake --install . --component Core
 cmake --install . --component Tools
 
-# Full development setup (runtime + development + cmake configs)  
+# SDK files for consumers
+cmake --install . --component Development
+
+# Full developer install assembled from components
 cmake --install . --component Core
-cmake --install . --component Core_Development
 cmake --install . --component Tools
+cmake --install . --component Development
 ```
 
-### Step 3: Verify Installation
-
-#### Full Installation Structure
+## Installation Structure
 
 ```
 install/
@@ -101,16 +58,16 @@ install/
 │   └── asset_converter                    # Tools
 ├── include/
 │   └── media/
-│       ├── core.h                        # Core_Development  
-│       └── dev_tools.h                   # Core_Development
+│       ├── core.h                         # Development
+│       └── dev_tools.h                    # Development
 ├── lib64/
-│   ├── libmedia_core.so.1.0.0           # Core
-│   ├── libmedia_core.so.1                # Core
-│   ├── libmedia_core.so                  # Core_Development
-│   └── libmedia_dev_tools.a              # Core_Development
+│   ├── libmedia_core.so.1.0.0             # Core
+│   ├── libmedia_core.so.1                 # Core
+│   ├── libmedia_core.so                   # Development namelink
+│   └── libmedia_dev_tools.a               # Development
 └── share/
     └── cmake/
-        └── MediaLib/                      # *_Development (shared config files)
+        └── MediaLib/                      # Development
             ├── MediaLibTargets.cmake
             ├── MediaLibTargets-noconfig.cmake
             ├── MediaLibConfig.cmake
@@ -118,130 +75,50 @@ install/
             └── MediaLib-config-version.cmake
 ```
 
-#### Component-Specific Installation Examples
-
-**Core Runtime Only** (minimal deployment):
-```
-install/lib64/libmedia_core.so.1.0.0
-```
-
-**Tools Runtime Only**:
-```
-install/bin/asset_converter
-```
-
-**Core Development Only**: 
-```
-install/include/media/core.h
-install/include/media/dev_tools.h  
-install/lib64/libmedia_dev_tools.a
-install/share/cmake/MediaLib/MediaLibConfig.cmake
-```
-
 ## Component Details
 
-### Core Logical Group
+**Core** contains runtime files for the shared library:
+- `libmedia_core.so.*`
+- No headers or static libraries.
 
-**Core**: Contains runtime files for the Core logical group
-- Shared libraries: `libmedia_core.so.*`
-- No headers or development files  
-- Minimal footprint for deployment
+**Tools** contains runtime tools:
+- `asset_converter`
 
-**Core_Development**: Contains development files for the Core logical group
-- Headers from both `media_core` and `media_dev_tools`
-- Static libraries: `libmedia_dev_tools.a`
-- Shared CMake configuration files for the `MediaLib` export
-
-### Tools Logical Group
-
-**Tools**: Contains runtime files for the Tools logical group
-- Executables: `asset_converter`
-- Independent from Core logical group
-
-**Tools_Development**: Typically empty for executable-only logical groups
-- Executables rarely have development artifacts
+**Development** contains SDK files for the export:
+- Headers from `media_core` and `media_dev_tools`
+- Static/import libraries
+- Shared-library namelinks
+- CMake package metadata for `find_package(MediaLib)`
 
 ## Using the Installed Package
 
-### Consumer Usage
-
 ```cmake
-# CMakeLists.txt  
 cmake_minimum_required(VERSION 3.25)
 project(media_app)
 
-# Find the unified MediaLib package
 find_package(MediaLib REQUIRED)
 
 add_executable(my_app main.cpp)
-
-# Link against targets from different logical groups
-target_link_libraries(my_app PRIVATE 
-  Media::media_core        # From Core logical group
-  Media::media_dev_tools   # From Core logical group  
-  # Media::asset_converter is an executable, not linkable
+target_link_libraries(my_app PRIVATE
+  Media::media_core
+  Media::media_dev_tools
 )
 ```
 
-### Available Targets
-
-The `MediaLib` package provides these targets:
-
-- `Media::media_core` - Shared library from Core logical group
-- `Media::media_dev_tools` - Static library from Core logical group  
-- `Media::asset_converter` - Executable from Tools logical group (not linkable)
-
-**Key Insight**: The consumer doesn't need to know about components - `find_package(MediaLib)` provides all targets. Components are purely for installation control.
-
-### Consumer Usage example
-
-```cpp
-// main.cpp
-#include "media/core.h"
-#ifdef MEDIA_DEV_TOOLS_AVAILABLE
-#include "media/dev_tools.h"
-#endif
-
-int main() {
-    // Initialize media system
-    if (!media::MediaCore::initialize()) {
-        return 1;
-    }
-    
-    // Load and play media
-    media::MediaCore::loadMedia("song.mp3", media::MediaType::AUDIO);
-    media::MediaCore::playAudio("song.mp3");
-    
-#ifdef MEDIA_DEV_TOOLS_AVAILABLE
-    // Use development tools if available
-    auto info = media::DevTools::analyzeFile("song.mp3");
-    std::cout << "Duration: " << info.duration << " seconds" << std::endl;
-#endif
-    
-    media::MediaCore::shutdown();
-    return 0;
-}
-```
+The consumer does not need to know about install components. Components only control which files are installed into a prefix or package.
 
 ## Asset Converter Tool
 
-The installed tool provides media conversion capabilities:
-
 ```bash
-# Basic usage (if the Tools component is installed)
 ./install/bin/asset_converter input.wav output.mp3
-
-# With options
 ./install/bin/asset_converter -f mp3 -q 95 input.wav output.mp3
-
-# Help
 ./install/bin/asset_converter --help
 ```
 
-## Component Prefix Pattern Features
+## Component Model Features
 
-- **Predictable Naming**: `COMPONENT="Core"` always creates `Core` (runtime), `Core_Development` (development)
-- **Logical Grouping**: Multiple targets (`media_core`, `media_dev_tools`) share the same logical group (`Core`)
-- **Shared Export**: All targets packaged under unified `MediaLib` export  
-- **No Dual Install Complexity**: Each target installs to exactly one runtime and one development component
-- **Mixed Target Types**: Handles shared libs, static libs, and executables uniformly
+- **Predictable runtime naming**: `COMPONENT Core` always installs runtime files into `Core`.
+- **One SDK component**: `Development` carries the development install tree, while shared-library consumers also need the related runtime components.
+- **Logical grouping**: multiple targets can share a runtime component.
+- **Shared export**: all targets are packaged under the unified `MediaLib` export.
+- **No partial SDK packages**: the shared CMake export is not copied into target-specific SDK components.

--- a/examples/components/README.md
+++ b/examples/components/README.md
@@ -17,10 +17,10 @@ MediaLib Package (shared export with Component Prefix Pattern):
 ├── Core             → libmedia_core.so (shared library runtime files) 
 ├── Core_Development → headers + libmedia_dev_tools.a + MediaLib CMake config files
 ├── Tools            → asset_converter (executable runtime)
-└── Tools_Development → (empty - executables typically have no dev files)
+└── Tools_Development → MediaLib CMake config files
 ```
 
-The Component Prefix Pattern creates predictable component names: `{COMPONENT}` for runtime, `{COMPONENT}_Development` for development. Shared CMake config files are installed with the first development component for the export, which is `Core_Development` in this example.
+The Component Prefix Pattern creates predictable component names: `{COMPONENT}` for runtime, `{COMPONENT}_Development` for development. Shared CMake config files are installed with each development component for the export, so both `Core_Development` and `Tools_Development` carry the package entry point.
 
 ## Building and Installing
 
@@ -66,7 +66,8 @@ cmake --install . --component Core_Development
 # Install only Tools runtime (executable)
 cmake --install . --component Tools
 
-# Tools typically have no development component (Tools_Development would be empty)
+# Tools_Development carries shared CMake package metadata for the export
+cmake --install . --component Tools_Development
 ```
 
 #### Install CMake Configuration
@@ -74,6 +75,7 @@ cmake --install . --component Tools
 ```bash
 # Install shared CMake config files (needed for find_package)
 cmake --install . --component Core_Development
+cmake --install . --component Tools_Development
 ```
 
 #### Deployment Scenarios
@@ -104,11 +106,11 @@ install/
 ├── lib64/
 │   ├── libmedia_core.so.1.0.0           # Core
 │   ├── libmedia_core.so.1                # Core
-│   ├── libmedia_core.so                  # Core
+│   ├── libmedia_core.so                  # Core_Development
 │   └── libmedia_dev_tools.a              # Core_Development
 └── share/
     └── cmake/
-        └── MediaLib/                      # Core_Development (shared config files)
+        └── MediaLib/                      # *_Development (shared config files)
             ├── MediaLibTargets.cmake
             ├── MediaLibTargets-noconfig.cmake
             ├── MediaLibConfig.cmake

--- a/examples/components/README.md
+++ b/examples/components/README.md
@@ -19,7 +19,7 @@ MediaLib package:
 └── Development  - headers, libmedia_dev_tools.a, namelinks, and MediaLib CMake config files
 ```
 
-`COMPONENT` does not create a second SDK component. It only names runtime files. The `Development` component carries SDK files for the whole export. For shared-library consumers, install `Development` plus the runtime components, or use package-manager packages that honor the generated component dependencies.
+`COMPONENT` does not create a second SDK component. It only names runtime files. The `Development` component carries SDK files for the whole export. Static and interface targets are SDK-only, so they do not create empty runtime packages. For shared-library consumers, install `Development` plus the runtime components, or use native packages configured to honor CPack component dependency metadata.
 
 ## Building and Installing
 
@@ -105,7 +105,7 @@ target_link_libraries(my_app PRIVATE
 )
 ```
 
-The consumer does not need to know about install components. Components only control which files are installed into a prefix or package.
+The consumer does not need to know about install components. Install components only control which files are installed into a prefix or package.
 
 ## Asset Converter Tool
 

--- a/examples/cpack-basic/README.md
+++ b/examples/cpack-basic/README.md
@@ -93,7 +93,7 @@ export_cpack(
   - macOS: `TGZ`, `DragNDrop`
 
 - **Component Dependencies**: Automatically configured
-  - `Development` depends on `Runtime`
+  - `Development` depends on `Runtime` and `Tools`
 
 ## Package Types Generated
 
@@ -127,23 +127,24 @@ cmake --install . --component Runtime
 install/
 └── <libdir>/
     ├── libcpack_lib.so.1.2.0
-    ├── libcpack_lib.so.1
-    └── libcpack_lib.so
+    └── libcpack_lib.so.1
 ```
 
 ### Development Package (Developers)
 
 ```bash
-# Install development files
+# Install SDK files
 cmake --install . --component Development
 
-# Result: Headers, static libs, CMake configs
+# Result: Headers, static libs, shared-library namelinks, CMake configs.
+# For manual component installs of shared libraries, install Runtime too before consuming.
 install/
 ├── include/
 │   └── cpack_lib/
 │       ├── core.h
 │       └── utils.h
 ├── <libdir>/
+│   ├── libcpack_lib.so
 │   └── libcpack_lib_utils.a
 └── share/
     └── cmake/
@@ -189,7 +190,8 @@ package_prefix="$(dirname "$(dirname "$(find . -path '*/bin/mytool' -type f -pri
 "$package_prefix/bin/mytool" --version
 "$package_prefix/bin/mytool" --help
 
-# Add development payload before testing find_package consumers
+# Add development payload before testing find_package consumers.
+# Runtime was extracted above; package-manager installs get that dependency automatically.
 tar -xzf ../MyLibrary-1.2.0-Linux-Development.tar.gz
 ```
 

--- a/examples/cpack-basic/README.md
+++ b/examples/cpack-basic/README.md
@@ -92,8 +92,10 @@ export_cpack(
   - Windows: `TGZ`, `ZIP`, `WIX` (if available)
   - macOS: `TGZ`, `DragNDrop`
 
-- **Component Dependencies**: Automatically configured
-  - `Development` depends on `Runtime` and `Tools`
+- **Component Relationships**: Recorded in CPack metadata
+  - `Development` records dependencies on the runtime components in the export
+  - Archive packages remain independent payload slices
+  - Native package enforcement depends on generator-specific CPack settings
 
 ## Package Types Generated
 
@@ -106,7 +108,7 @@ export_cpack(
 ### Linux Packages (DEB/RPM)
 
 - Native package management integration
-- Automatic dependency handling
+- Component dependency metadata can be mapped by generator-specific settings
 - Component-based installation support
 
 ### Windows Installer (WIX)
@@ -172,7 +174,7 @@ install/
 # For component TGZ packages
 tar -tzf MyLibrary-1.2.0-Linux-Runtime.tar.gz
 tar -tzf MyLibrary-1.2.0-Linux-Development.tar.gz
-tar -tzf MyLibrary-1.2.0-Linux-TOOLS.tar.gz
+tar -tzf MyLibrary-1.2.0-Linux-Tools.tar.gz
 ```
 
 ### Test Package Installation
@@ -183,7 +185,7 @@ tar -tzf MyLibrary-1.2.0-Linux-TOOLS.tar.gz
 mkdir test-install
 cd test-install
 tar -xzf ../MyLibrary-1.2.0-Linux-Runtime.tar.gz
-tar -xzf ../MyLibrary-1.2.0-Linux-TOOLS.tar.gz
+tar -xzf ../MyLibrary-1.2.0-Linux-Tools.tar.gz
 package_prefix="$(dirname "$(dirname "$(find . -path '*/bin/mytool' -type f -print -quit)")")"
 
 # Verify the tool works
@@ -191,7 +193,7 @@ package_prefix="$(dirname "$(dirname "$(find . -path '*/bin/mytool' -type f -pri
 "$package_prefix/bin/mytool" --help
 
 # Add development payload before testing find_package consumers.
-# Runtime was extracted above; package-manager installs get that dependency automatically.
+# Runtime was extracted above; component archives do not fetch dependency archives.
 tar -xzf ../MyLibrary-1.2.0-Linux-Development.tar.gz
 ```
 

--- a/examples/cpack-signed/README.md
+++ b/examples/cpack-signed/README.md
@@ -80,10 +80,10 @@ Example package names for the current example version (`1.2.0`) are:
 **📦 Packages**
 - `MySignedLibrary-1.2.0-Linux-Development.tar.gz`
 - `MySignedLibrary-1.2.0-Linux-Runtime.tar.gz`
-- `MySignedLibrary-1.2.0-Linux-TOOLS.tar.gz`
+- `MySignedLibrary-1.2.0-Linux-Tools.tar.gz`
 - `MySignedLibrary-1.2.0-Linux-Development.zip`
 - `MySignedLibrary-1.2.0-Linux-Runtime.zip`
-- `MySignedLibrary-1.2.0-Linux-TOOLS.zip`
+- `MySignedLibrary-1.2.0-Linux-Tools.zip`
 
 **🔐 Signatures**  
 - `*.sig` - GPG detached signatures for each package
@@ -178,10 +178,10 @@ cp ../verify_template.sh.in my_custom_verify.sh.in
 #
 # ✓ MySignedLibrary-1.2.0-Linux-Development.tar.gz verified successfully
 # ✓ MySignedLibrary-1.2.0-Linux-Runtime.tar.gz verified successfully
-# ✓ MySignedLibrary-1.2.0-Linux-TOOLS.tar.gz verified successfully
+# ✓ MySignedLibrary-1.2.0-Linux-Tools.tar.gz verified successfully
 # ✓ MySignedLibrary-1.2.0-Linux-Development.zip verified successfully
 # ✓ MySignedLibrary-1.2.0-Linux-Runtime.zip verified successfully
-# ✓ MySignedLibrary-1.2.0-Linux-TOOLS.zip verified successfully
+# ✓ MySignedLibrary-1.2.0-Linux-Tools.zip verified successfully
 #
 # Verification Results:
 #   Total packages: 6

--- a/export_cpack.cmake
+++ b/export_cpack.cmake
@@ -116,17 +116,16 @@ endif()
 #
 # Behavior:
 #   - Automatically detects components from previous target_install_package calls
-#   - Auto-detects logical component groups from naming patterns (e.g., Core and Core_Development → Core group)
+#   - Auto-detects components registered by target_install_package()
 #   - Sets platform-appropriate default generators (TGZ/ZIP on all, DEB/RPM on Linux, WIX on Windows)
 #   - Configures component dependencies and descriptions automatically
 #   - Handles both single-component and multi-component packages
 #   - Integrates with existing CMake project metadata
 #
 # Auto-detected components and their typical usage:
-#   - Runtime/PREFIX: Shared libraries, executables needed at runtime (when COMPONENT is PREFIX)
-#   - Development/PREFIX_Development: Headers, static libraries, CMake config files
-#   - Logical Groups: Auto-created from prefixes (e.g., Core + Core_Development → Core group)
-#   - Component Dependencies: *_Development automatically depends on corresponding runtime component
+#   - Runtime or named COMPONENT values: Shared libraries and executables needed at runtime
+#   - Development: Headers, static/import libraries, namelinks, CMake config files, and CPS metadata by default
+#   - Component Dependencies: Development automatically depends on the runtime components registered for the same export
 #
 # Examples:
 #   # Basic usage with auto-detection (CPack is automatically included)
@@ -282,12 +281,11 @@ function(_tip_component_list_has_cpack_dependencies OUT_VAR)
       PARENT_SCOPE)
 endfunction()
 
-# Helper function to determine if component groups should be auto-enabled Auto-enable when we detect logical component prefixes (e.g., Core/Core_Development)
+# Helper function to determine if component groups should be auto-enabled for legacy split SDK component names.
 function(_should_auto_enable_component_groups component_list)
   foreach(component ${component_list})
-    # NEW SCHEME: Check if component follows COMPONENT_Development pattern
+    # Legacy compatibility: explicit COMPONENT_Development names can still be grouped when supplied directly to export_cpack().
     if(component MATCHES "^(.+)_Development$")
-      # Found at least one new-style development component - enable grouping
       set(_ENABLE_GROUPS
           TRUE
           PARENT_SCOPE)
@@ -308,7 +306,7 @@ function(_configure_logical_component_groups component_list)
   # Parse components to extract logical groups and categorize components
   foreach(component ${component_list})
     if(component MATCHES "^(.+)_Development$")
-      # NEW SCHEME: Component follows COMPONENT_Development pattern
+      # Legacy split SDK component pattern.
       set(group_name "${CMAKE_MATCH_1}")
       set(component_type "Development")
 
@@ -334,7 +332,7 @@ function(_configure_logical_component_groups component_list)
       # Traditional standalone Development component
       list(APPEND development_components "${component}")
     else()
-      # NEW SCHEME: Component without _Development suffix is runtime component Only add to runtime if there's a corresponding _Development component
+      # Legacy split SDK runtime component. Only add to runtime if there is a matching explicit _Development component.
       if("${component}_Development" IN_LIST component_list)
         list(APPEND runtime_components "${component}")
         if(NOT component IN_LIST logical_groups)
@@ -360,13 +358,13 @@ function(_configure_logical_component_groups component_list)
     set(dependencies "")
 
     if(component MATCHES "^(.+)_Development$")
-      # NEW SCHEME: COMPONENT_Development pattern
+      # Legacy split SDK component pattern.
       set(group_name "${CMAKE_MATCH_1}")
       string(TOUPPER "${group_name}" group_upper)
 
       _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_GROUP "${group_upper}")
 
-      # Set up dependencies: Development components depend on Runtime components within same group PLUS the global Runtime component if it exists and is different
+      # Legacy dependency setup: split development components depend on their runtime component and global Runtime when present.
       if("${group_name}" IN_LIST component_list)
         list(APPEND dependencies "${group_name}")
       endif()
@@ -375,7 +373,7 @@ function(_configure_logical_component_groups component_list)
         list(APPEND dependencies "Runtime")
       endif()
     elseif("${component}_Development" IN_LIST component_list)
-      # NEW SCHEME: Runtime component (has corresponding _Development component)
+      # Legacy split SDK runtime component.
       string(TOUPPER "${component}" group_upper)
       _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_GROUP "${group_upper}")
       # Custom runtime components should depend on global Runtime if it exists and is different
@@ -887,17 +885,18 @@ function(_execute_deferred_cpack_config)
       _configure_logical_component_groups("${ARG_COMPONENTS}")
     endif()
 
-    # Set component descriptions (enhanced for prefix patterns)
+    # Set component descriptions.
+    get_property(_tip_detected_components GLOBAL PROPERTY "_TIP_DETECTED_COMPONENTS")
     foreach(component ${ARG_COMPONENTS})
       string(TOUPPER ${component} component_upper)
 
       if(component MATCHES "^(.+)_Development$")
-        # NEW SCHEME: COMPONENT_Development pattern
+        # Legacy split SDK component pattern.
         set(group_name "${CMAKE_MATCH_1}")
         _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DESCRIPTION "${group_name} headers, static libraries, and development files")
         _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DISPLAY_NAME "${group_name} Development")
       elseif("${component}_Development" IN_LIST ARG_COMPONENTS)
-        # NEW SCHEME: Runtime component (has corresponding _Development component)
+        # Legacy split SDK runtime component.
         _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DESCRIPTION "${component} runtime libraries and executables")
         _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DISPLAY_NAME "${component} Runtime")
       elseif(component STREQUAL "Runtime")
@@ -912,6 +911,9 @@ function(_execute_deferred_cpack_config)
       elseif(component STREQUAL "Documentation")
         _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DESCRIPTION "Documentation and examples")
         _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DISPLAY_NAME "Documentation")
+      elseif(component IN_LIST _tip_detected_components)
+        _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DESCRIPTION "${component} runtime libraries and executables")
+        _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DISPLAY_NAME "${component} Runtime")
       else()
         _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DESCRIPTION "${component} component")
         _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DISPLAY_NAME "${component}")
@@ -1121,8 +1123,7 @@ function(_configure_gpg_signing)
     set(ARG_PASSPHRASE_FILE "$ENV{GPG_PASSPHRASE_FILE}")
   endif()
 
-  # Enable checksums by default when signing is enabled. Without signing, only
-  # configure the post-build script when checksums were explicitly requested.
+  # Enable checksums by default when signing is enabled. Without signing, only configure the post-build script when checksums were explicitly requested.
   if(NOT DEFINED ARG_GENERATE_CHECKSUMS OR "${ARG_GENERATE_CHECKSUMS}" STREQUAL "")
     if(ARG_SIGNING_KEY)
       set(ARG_GENERATE_CHECKSUMS ON)
@@ -1199,7 +1200,9 @@ function(_configure_gpg_signing)
     set(RPMSIGN_EXECUTABLE "")
   endif()
 
-  if(ARG_SIGNING_KEY AND ARG_PASSPHRASE_FILE AND ARG_REQUIRE_RPMSIGN)
+  if(ARG_SIGNING_KEY
+     AND ARG_PASSPHRASE_FILE
+     AND ARG_REQUIRE_RPMSIGN)
     project_log(WARNING "GPG_PASSPHRASE_FILE is used for detached signatures only; embedded RPM signing uses rpmsign and the configured GPG agent.")
   endif()
 

--- a/export_cpack.cmake
+++ b/export_cpack.cmake
@@ -179,6 +179,21 @@ function(_tip_find_export_cpack_resource_file file_name out_var)
   project_log(FATAL_ERROR "Package resource '${file_name}' not found. Checked: ${_tip_resource_candidates}")
 endfunction()
 
+function(_tip_finalize_registered_exports_for_cpack)
+  if(NOT COMMAND _auto_finalize_single_export)
+    return()
+  endif()
+
+  get_property(_tip_registered_exports GLOBAL PROPERTY "_CMAKE_PACKAGE_REGISTERED_EXPORTS")
+  foreach(_tip_export_name IN LISTS _tip_registered_exports)
+    get_property(_tip_export_finalized GLOBAL PROPERTY "_CMAKE_PACKAGE_EXPORT_${_tip_export_name}_FINALIZED")
+    if(NOT _tip_export_finalized)
+      project_log(DEBUG "Finalizing export '${_tip_export_name}' before CPack configuration")
+      _auto_finalize_single_export("${_tip_export_name}")
+    endif()
+  endforeach()
+endfunction()
+
 function(export_cpack)
   # Check if export_cpack has already been called (not deferred execution)
   get_property(cpack_config_stored GLOBAL PROPERTY "_TIP_CPACK_CONFIG_STORED")
@@ -235,6 +250,36 @@ function(_tip_append_cpack_list_var_unique var_name)
     endif()
   endforeach()
   _tip_store_cpack_var("${var_name}" "${updated_value}")
+endfunction()
+
+function(_tip_cpack_component_dependency_property_name OUT_VAR COMPONENT_NAME)
+  string(SHA256 _tip_component_hash "${COMPONENT_NAME}")
+  set(${OUT_VAR}
+      "_TIP_CPACK_COMPONENT_DEPENDENCY_${_tip_component_hash}"
+      PARENT_SCOPE)
+endfunction()
+
+function(_tip_get_cpack_component_dependencies COMPONENT_NAME OUT_VAR)
+  _tip_cpack_component_dependency_property_name(_tip_component_dependency_property "${COMPONENT_NAME}")
+  get_property(_tip_component_dependencies GLOBAL PROPERTY "${_tip_component_dependency_property}")
+  set(${OUT_VAR}
+      "${_tip_component_dependencies}"
+      PARENT_SCOPE)
+endfunction()
+
+function(_tip_component_list_has_cpack_dependencies OUT_VAR)
+  set(_tip_has_dependencies FALSE)
+  foreach(_tip_component IN LISTS ARGN)
+    _tip_get_cpack_component_dependencies("${_tip_component}" _tip_component_dependencies)
+    if(_tip_component_dependencies)
+      set(_tip_has_dependencies TRUE)
+      break()
+    endif()
+  endforeach()
+
+  set(${OUT_VAR}
+      "${_tip_has_dependencies}"
+      PARENT_SCOPE)
 endfunction()
 
 # Helper function to determine if component groups should be auto-enabled Auto-enable when we detect logical component prefixes (e.g., Core/Core_Development)
@@ -312,6 +357,7 @@ function(_configure_logical_component_groups component_list)
   # Configure component group assignments and dependencies
   foreach(component ${component_list})
     string(TOUPPER "${component}" component_upper)
+    set(dependencies "")
 
     if(component MATCHES "^(.+)_Development$")
       # NEW SCHEME: COMPONENT_Development pattern
@@ -321,7 +367,6 @@ function(_configure_logical_component_groups component_list)
       _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_GROUP "${group_upper}")
 
       # Set up dependencies: Development components depend on Runtime components within same group PLUS the global Runtime component if it exists and is different
-      set(dependencies "")
       if("${group_name}" IN_LIST component_list)
         list(APPEND dependencies "${group_name}")
       endif()
@@ -329,25 +374,32 @@ function(_configure_logical_component_groups component_list)
       if("Runtime" IN_LIST component_list AND NOT group_name STREQUAL "Runtime")
         list(APPEND dependencies "Runtime")
       endif()
-      if(dependencies)
-        _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DEPENDS "${dependencies}")
-        project_log(DEBUG "Set dependency: ${component} depends on ${dependencies}")
-      endif()
     elseif("${component}_Development" IN_LIST component_list)
       # NEW SCHEME: Runtime component (has corresponding _Development component)
       string(TOUPPER "${component}" group_upper)
       _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_GROUP "${group_upper}")
       # Custom runtime components should depend on global Runtime if it exists and is different
       if("Runtime" IN_LIST component_list AND NOT component STREQUAL "Runtime")
-        _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DEPENDS "Runtime")
-        project_log(DEBUG "Set dependency: ${component} depends on Runtime")
+        list(APPEND dependencies "Runtime")
       endif()
     else()
       # Traditional component - set up classic Runtime/Development dependency
       if(component STREQUAL "Development" AND "Runtime" IN_LIST component_list)
-        _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DEPENDS "Runtime")
-        project_log(DEBUG "Set traditional dependency: Development depends on Runtime")
+        list(APPEND dependencies "Runtime")
       endif()
+    endif()
+
+    _tip_get_cpack_component_dependencies("${component}" _tip_export_component_dependencies)
+    if(_tip_export_component_dependencies)
+      list(APPEND dependencies ${_tip_export_component_dependencies})
+    endif()
+    if(dependencies)
+      list(REMOVE_ITEM dependencies "${component}")
+      list(REMOVE_DUPLICATES dependencies)
+    endif()
+    if(dependencies)
+      _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DEPENDS "${dependencies}")
+      project_log(DEBUG "Set dependency: ${component} depends on ${dependencies}")
     endif()
   endforeach()
 
@@ -414,6 +466,7 @@ function(_execute_deferred_cpack_config)
   if(NOT args)
     return()
   endif()
+  _tip_finalize_registered_exports_for_cpack()
   get_property(_tip_cpack_config_source_dir GLOBAL PROPERTY "_TIP_CPACK_CONFIG_SOURCE_DIR")
   if(NOT _tip_cpack_config_source_dir)
     set(_tip_cpack_config_source_dir "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -822,8 +875,13 @@ function(_execute_deferred_cpack_config)
 
     # Configure component grouping (auto-detect logical groups from component naming)
     _should_auto_enable_component_groups("${ARG_COMPONENTS}")
-    if(ARG_COMPONENT_GROUPS OR _ENABLE_GROUPS)
-      _tip_store_cpack_var(CPACK_COMPONENTS_GROUPING "ONE_PER_GROUP")
+    _tip_component_list_has_cpack_dependencies(_tip_has_export_component_dependencies ${ARG_COMPONENTS})
+    if(ARG_COMPONENT_GROUPS
+       OR _ENABLE_GROUPS
+       OR _tip_has_export_component_dependencies)
+      if(ARG_COMPONENT_GROUPS OR _ENABLE_GROUPS)
+        _tip_store_cpack_var(CPACK_COMPONENTS_GROUPING "ONE_PER_GROUP")
+      endif()
 
       # Auto-detect logical groups from component naming patterns
       _configure_logical_component_groups("${ARG_COMPONENTS}")

--- a/export_cpack.cmake
+++ b/export_cpack.cmake
@@ -100,7 +100,8 @@ endif()
 #   GENERATORS              - Explicit list of CPack generators to use (TGZ, DEB, RPM, CONTAINER, etc.)
 #   COMPONENTS              - Explicit list of components to package (default: auto-detected)
 #   COMPONENT_GROUPS        - Enable component grouping (default: auto-detected from prefixes)
-#   DEFAULT_COMPONENTS      - Components installed by default (default: Runtime)
+#   DEFAULT_COMPONENTS      - Components selected by default in installers that honor CPack DISABLED metadata.
+#                             Defaults to detected runtime-payload components, or Development when no runtime payload exists.
 #   ENABLE_COMPONENT_INSTALL - Force component-based installation
 #   ARCHIVE_FORMAT          - Format for archive generators (TGZ, ZIP, etc.)
 #   NO_DEFAULT_GENERATORS   - Don't set default generators based on platform
@@ -109,23 +110,23 @@ endif()
 #   CONTAINER_RUNTIME       - Explicit runtime command for container build/save (default: podman)
 #   CONTAINER_ENTRYPOINT    - Entrypoint path inside the container rootfs. If omitted, exactly one executable must be discoverable.
 #   CONTAINER_ARCHIVE_FORMAT - Archive format for saved image (default: oci-archive for podman, docker-archive for docker)
-#   CONTAINER_COMPONENTS    - Components merged into the container rootfs (default: DEFAULT_COMPONENTS, or declared runtime components when the implicit Runtime default is not declared)
+#   CONTAINER_COMPONENTS    - Components merged into the container rootfs (default: DEFAULT_COMPONENTS)
 #   CONTAINER_ROOTFS_OVERLAYS - Directories whose contents are merged into the rootfs after components
 #   ADDITIONAL_CPACK_VARS   - Additional CPack variables as key-value pairs
 #                             Can override any auto-detected settings including architecture
 #
 # Behavior:
 #   - Automatically detects components from previous target_install_package calls
-#   - Auto-detects components registered by target_install_package()
+#   - Registers runtime components only for targets with runtime payloads
 #   - Sets platform-appropriate default generators (TGZ/ZIP on all, DEB/RPM on Linux, WIX on Windows)
-#   - Configures component dependencies and descriptions automatically
+#   - Records CPack component metadata; native package dependency enforcement is generator-specific
 #   - Handles both single-component and multi-component packages
 #   - Integrates with existing CMake project metadata
 #
 # Auto-detected components and their typical usage:
-#   - Runtime or named COMPONENT values: Shared libraries and executables needed at runtime
+#   - Runtime or named COMPONENT values: shared libraries, modules, and executables needed at runtime
 #   - Development: Headers, static/import libraries, namelinks, CMake config files, and CPS metadata by default
-#   - Component Dependencies: Development automatically depends on the runtime components registered for the same export
+#   - Component dependencies: Development records dependencies on runtime components registered for the same export
 #
 # Examples:
 #   # Basic usage with auto-detection (CPack is automatically included)
@@ -394,6 +395,15 @@ function(_configure_logical_component_groups component_list)
     if(dependencies)
       list(REMOVE_ITEM dependencies "${component}")
       list(REMOVE_DUPLICATES dependencies)
+      set(_tip_filtered_dependencies "")
+      foreach(_tip_dependency IN LISTS dependencies)
+        if(_tip_dependency IN_LIST component_list)
+          list(APPEND _tip_filtered_dependencies "${_tip_dependency}")
+        else()
+          project_log(DEBUG "Skipping dependency '${_tip_dependency}' for component '${component}' because it is not in CPACK_COMPONENTS_ALL")
+        endif()
+      endforeach()
+      set(dependencies ${_tip_filtered_dependencies})
     endif()
     if(dependencies)
       _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DEPENDS "${dependencies}")
@@ -559,6 +569,11 @@ function(_execute_deferred_cpack_config)
   if(ARG_UNPARSED_ARGUMENTS)
     project_log(FATAL_ERROR "Unknown arguments for export_cpack(): ${ARG_UNPARSED_ARGUMENTS}")
   endif()
+  set(_tip_components_explicit FALSE)
+  set(_tip_components_keyword "COMPONENTS")
+  if(_tip_components_keyword IN_LIST _tip_cpack_parse_args)
+    set(_tip_components_explicit TRUE)
+  endif()
 
   # Set default package metadata from project properties
   if(NOT ARG_PACKAGE_NAME)
@@ -621,8 +636,24 @@ function(_execute_deferred_cpack_config)
   set(_tip_default_components_explicit TRUE)
   if(NOT ARG_DEFAULT_COMPONENTS)
     set(_tip_default_components_explicit FALSE)
-    set(ARG_DEFAULT_COMPONENTS "Runtime")
+    set(ARG_DEFAULT_COMPONENTS "")
+    get_property(_tip_detected_runtime_components GLOBAL PROPERTY "_TIP_DETECTED_RUNTIME_COMPONENTS")
+    foreach(_tip_default_component_candidate IN LISTS _tip_detected_runtime_components)
+      if(_tip_default_component_candidate IN_LIST ARG_COMPONENTS)
+        list(APPEND ARG_DEFAULT_COMPONENTS "${_tip_default_component_candidate}")
+      endif()
+    endforeach()
+    if(NOT ARG_DEFAULT_COMPONENTS AND "Development" IN_LIST ARG_COMPONENTS)
+      set(ARG_DEFAULT_COMPONENTS "Development")
+    elseif(NOT ARG_DEFAULT_COMPONENTS)
+      set(ARG_DEFAULT_COMPONENTS ${ARG_COMPONENTS})
+    endif()
   endif()
+  foreach(_tip_default_component IN LISTS ARG_DEFAULT_COMPONENTS)
+    if(NOT _tip_default_component IN_LIST ARG_COMPONENTS)
+      project_log(FATAL_ERROR "DEFAULT_COMPONENTS contains unknown component '${_tip_default_component}'. Known components: ${ARG_COMPONENTS}")
+    endif()
+  endforeach()
 
   # Auto-detect generators based on platform if not specified
   if(NOT ARG_GENERATORS AND NOT ARG_NO_DEFAULT_GENERATORS)
@@ -797,24 +828,6 @@ function(_execute_deferred_cpack_config)
       set(container_components ${ARG_CONTAINER_COMPONENTS})
     else()
       set(container_components ${ARG_DEFAULT_COMPONENTS})
-      set(_tip_container_default_components_valid TRUE)
-      foreach(container_component IN LISTS container_components)
-        if(NOT container_component IN_LIST ARG_COMPONENTS)
-          set(_tip_container_default_components_valid FALSE)
-        endif()
-      endforeach()
-      if(NOT _tip_container_default_components_valid AND NOT _tip_default_components_explicit)
-        set(container_components "")
-        foreach(container_component_candidate IN LISTS ARG_COMPONENTS)
-          if(container_component_candidate STREQUAL "Development" OR container_component_candidate MATCHES "_Development$")
-            continue()
-          endif()
-          list(APPEND container_components "${container_component_candidate}")
-        endforeach()
-        if(container_components)
-          project_log(VERBOSE "Container components defaulted to declared runtime components: ${container_components}")
-        endif()
-      endif()
     endif()
     if(NOT container_components)
       project_log(FATAL_ERROR "CONTAINER_COMPONENTS resolved to an empty list. Set CONTAINER_COMPONENTS or DEFAULT_COMPONENTS explicitly.")
@@ -855,9 +868,11 @@ function(_execute_deferred_cpack_config)
   if(ARG_COMPONENTS)
     _tip_store_cpack_var(CPACK_COMPONENTS_ALL "${ARG_COMPONENTS}")
 
-    # Enable component installation if more than one component or explicitly requested
+    # Enable component installation if more than one component, explicit components were requested, or explicitly requested.
     list(LENGTH ARG_COMPONENTS component_count)
-    if(component_count GREATER 1 OR ARG_ENABLE_COMPONENT_INSTALL)
+    if(component_count GREATER 1
+       OR ARG_ENABLE_COMPONENT_INSTALL
+       OR _tip_components_explicit)
       _tip_store_cpack_var(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
       _tip_store_cpack_var(CPACK_DEB_COMPONENT_INSTALL ON)
       _tip_store_cpack_var(CPACK_RPM_COMPONENT_INSTALL ON)
@@ -866,9 +881,16 @@ function(_execute_deferred_cpack_config)
       endif()
     endif()
 
-    # Set default components
+    # Mark non-default components as unselected by default for installers that honor CPack component metadata.
     if(ARG_DEFAULT_COMPONENTS)
-      _tip_store_cpack_var(CPACK_COMPONENTS_DEFAULT "${ARG_DEFAULT_COMPONENTS}")
+      foreach(component ${ARG_COMPONENTS})
+        string(TOUPPER ${component} component_upper)
+        if(component IN_LIST ARG_DEFAULT_COMPONENTS)
+          _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DISABLED FALSE)
+        else()
+          _tip_store_cpack_var(CPACK_COMPONENT_${component_upper}_DISABLED TRUE)
+        endif()
+      endforeach()
     endif()
 
     # Configure component grouping (auto-detect logical groups from component naming)

--- a/export_cpack.cmake
+++ b/export_cpack.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.1)
+  list_file_include_guard(VERSION 7.0.2)
 else()
   if(COMMAND project_log)
     project_log(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")

--- a/target_configure_sources.cmake
+++ b/target_configure_sources.cmake
@@ -3,7 +3,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.1)
+  list_file_include_guard(VERSION 7.0.2)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -1184,6 +1184,29 @@ function(target_prepare_package TARGET_NAME)
 endfunction(target_prepare_package)
 
 # ~~~
+# Helper: Determine whether a target contributes runtime payload through this wrapper.
+#
+# Runtime components are reserved for artifacts a consumer may need at execution time.
+# Static, interface, and object targets contribute SDK/config payload only.
+# ~~~
+function(_tip_target_has_runtime_payload OUT_VAR TARGET_NAME)
+  set(_tip_has_runtime_payload FALSE)
+
+  if(TARGET "${TARGET_NAME}")
+    get_target_property(_tip_target_type "${TARGET_NAME}" TYPE)
+    if(_tip_target_type STREQUAL "EXECUTABLE"
+       OR _tip_target_type STREQUAL "SHARED_LIBRARY"
+       OR _tip_target_type STREQUAL "MODULE_LIBRARY")
+      set(_tip_has_runtime_payload TRUE)
+    endif()
+  endif()
+
+  set(${OUT_VAR}
+      "${_tip_has_runtime_payload}"
+      PARENT_SCOPE)
+endfunction()
+
+# ~~~
 # Helper: Collect component information from all targets in an export.
 #
 # This internal helper function gathers component assignments across all targets
@@ -1206,22 +1229,26 @@ function(_collect_export_components EXPORT_PROPERTY_PREFIX TARGETS)
     get_property(TARGET_RUNTIME_COMP GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_RUNTIME_COMPONENT")
     get_property(TARGET_DEV_COMP GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_DEVELOPMENT_COMPONENT")
 
-    # Prefer the canonical component names stored by target_prepare_package().
-    if(TARGET_RUNTIME_COMP)
-      set(RUNTIME_COMPONENT_NAME "${TARGET_RUNTIME_COMP}")
-    else()
-      set(RUNTIME_COMPONENT_NAME "Runtime")
-    endif()
-
     if(TARGET_DEV_COMP)
       set(DEV_COMPONENT_NAME "${TARGET_DEV_COMP}")
     else()
       set(DEV_COMPONENT_NAME "Development")
     endif()
 
-    list(APPEND ALL_RUNTIME_COMPONENTS ${RUNTIME_COMPONENT_NAME})
+    _tip_target_has_runtime_payload(_tip_has_runtime_payload "${TARGET_NAME}")
+    if(_tip_has_runtime_payload)
+      # Prefer the canonical component names stored by target_prepare_package().
+      if(TARGET_RUNTIME_COMP)
+        set(RUNTIME_COMPONENT_NAME "${TARGET_RUNTIME_COMP}")
+      else()
+        set(RUNTIME_COMPONENT_NAME "Runtime")
+      endif()
+
+      list(APPEND ALL_RUNTIME_COMPONENTS ${RUNTIME_COMPONENT_NAME})
+      list(APPEND COMPONENT_TARGET_MAP "${RUNTIME_COMPONENT_NAME}:${TARGET_NAME}")
+    endif()
+
     list(APPEND ALL_DEVELOPMENT_COMPONENTS ${DEV_COMPONENT_NAME})
-    list(APPEND COMPONENT_TARGET_MAP "${RUNTIME_COMPONENT_NAME}:${TARGET_NAME}")
     list(APPEND COMPONENT_TARGET_MAP "${DEV_COMPONENT_NAME}:${TARGET_NAME}")
   endforeach()
 
@@ -1506,6 +1533,19 @@ function(finalize_package)
       list(REMOVE_DUPLICATES detected_components)
       set_property(GLOBAL PROPERTY "_TIP_DETECTED_COMPONENTS" "${detected_components}")
     endif()
+
+    if(ALL_RUNTIME_COMPONENTS)
+      get_property(_tip_detected_runtime_components GLOBAL PROPERTY "_TIP_DETECTED_RUNTIME_COMPONENTS")
+      foreach(component ${ALL_RUNTIME_COMPONENTS})
+        if(NOT component IN_LIST _tip_detected_runtime_components)
+          list(APPEND _tip_detected_runtime_components "${component}")
+        endif()
+      endforeach()
+      if(_tip_detected_runtime_components)
+        list(REMOVE_DUPLICATES _tip_detected_runtime_components)
+        set_property(GLOBAL PROPERTY "_TIP_DETECTED_RUNTIME_COMPONENTS" "${_tip_detected_runtime_components}")
+      endif()
+    endif()
   else()
     project_log(VERBOSE "Export '${ARG_EXPORT_NAME}' finalizing ${target_count} ${target_label}: [${TARGETS}]")
   endif()
@@ -1533,6 +1573,7 @@ function(finalize_package)
   set(_tip_cps_default_target_names "")
   set(_tip_cps_default_target_types STATIC_LIBRARY SHARED_LIBRARY INTERFACE_LIBRARY)
   set(_tip_cps_unsupported_target_types EXECUTABLE MODULE_LIBRARY)
+  set(_tip_exported_alias_names "")
 
   # Install each target separately with its own components
   foreach(TARGET_NAME ${TARGETS})
@@ -1551,6 +1592,11 @@ function(finalize_package)
     if("${TARGET_ALIAS_NAME}" STREQUAL "")
       set(TARGET_ALIAS_NAME "${TARGET_NAME}")
     endif()
+
+    if(TARGET_ALIAS_NAME IN_LIST _tip_exported_alias_names)
+      project_log(FATAL_ERROR "Duplicate exported target name '${TARGET_ALIAS_NAME}' in export '${ARG_EXPORT_NAME}'. Use unique ALIAS_NAME values for each target.")
+    endif()
+    list(APPEND _tip_exported_alias_names "${TARGET_ALIAS_NAME}")
     list(APPEND _tip_cps_exported_target_names "${TARGET_ALIAS_NAME}")
 
     get_target_property(_tip_cps_target_type ${TARGET_NAME} TYPE)
@@ -2098,6 +2144,13 @@ function(finalize_package)
   # Prepare component dependencies content for template substitution
   set(PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "")
   set(_tip_find_package_components ${ALL_UNIQUE_COMPONENTS} ${COMPONENT_DEPENDENCY_COMPONENTS})
+  foreach(TARGET_NAME IN LISTS TARGETS)
+    get_property(_tip_target_component_explicit GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_COMPONENT_EXPLICIT")
+    if(_tip_target_component_explicit)
+      get_property(_tip_target_runtime_component GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_RUNTIME_COMPONENT")
+      list(APPEND _tip_find_package_components "${_tip_target_runtime_component}")
+    endif()
+  endforeach()
   if(_tip_find_package_components)
     list(REMOVE_DUPLICATES _tip_find_package_components)
     set(_tip_known_find_components "")

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.1)
+  list_file_include_guard(VERSION 7.0.2)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -2201,10 +2201,12 @@ function(finalize_package)
 
       get_filename_component(file_name "${cmake_file}" NAME)
 
-      install(
-        FILES "${SRC_CMAKE_FILE}"
-        DESTINATION "${CMAKE_CONFIG_DESTINATION}"
-        ${CONFIG_COMPONENT_ARGS})
+      foreach(_tip_config_component IN LISTS CONFIG_COMPONENTS)
+        install(
+          FILES "${SRC_CMAKE_FILE}"
+          DESTINATION "${CMAKE_CONFIG_DESTINATION}"
+          COMPONENT "${_tip_config_component}")
+      endforeach()
 
       string(APPEND PACKAGE_INCLUDE_ON_FIND_PACKAGE "include(\"\${CMAKE_CURRENT_LIST_DIR}/${file_name}\")\n")
     endforeach()

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -114,7 +114,7 @@ endif()
 #   INCLUDE_DESTINATION          - Destination for installed headers (default: `${CMAKE_INSTALL_INCLUDEDIR}`).
 #   MODULE_DESTINATION           - Destination for C++20 modules (default: `${CMAKE_INSTALL_INCLUDEDIR}`).
 #   CMAKE_CONFIG_DESTINATION     - Destination for CMake config files (default: `${CMAKE_INSTALL_DATADIR}/cmake/${EXPORT_NAME}`).
-#   COMPONENT                    - Component prefix for installation. Creates `${COMPONENT}` for runtime and `${COMPONENT}_Development` for development files.
+#   COMPONENT                    - Optional runtime component name. Development files stay in the shared `Development` component.
 #                                  If omitted, uses default "Runtime" and "Development" components.
 #   DEBUG_POSTFIX                - Debug postfix for library names (default: "d").
 #   ADDITIONAL_FILES             - Additional files to install, relative to source dir.
@@ -151,10 +151,10 @@ endif()
 #   # Basic installation
 #   target_install_package(my_library)
 #
-#   # Custom version and component prefix
+#   # Custom version and runtime component
 #   target_install_package(my_library
 #     VERSION 1.2.3
-#     COMPONENT "Core")  # Creates Core and Core_Development components
+#     COMPONENT "Core")  # Creates Core runtime files and installs SDK files in Development
 #
 #   # Multi-config with default debug postfix "d", e.g if debug then -> my_libraryd.so
 #   target_install_package(my_library
@@ -457,11 +457,8 @@ endfunction()
 function(target_prepare_package TARGET_NAME)
   # Check for deprecated parameters BEFORE parsing
   if("RUNTIME_COMPONENT" IN_LIST ARGN OR "DEVELOPMENT_COMPONENT" IN_LIST ARGN)
-    message(
-      FATAL_ERROR
-        "RUNTIME_COMPONENT and DEVELOPMENT_COMPONENT parameters are deprecated. "
-        "Use COMPONENT instead - it will automatically create '{COMPONENT}' for runtime files and '{COMPONENT}_Development' for development files. "
-        "This provides cleaner, more consistent component naming.")
+    message(FATAL_ERROR "RUNTIME_COMPONENT and DEVELOPMENT_COMPONENT parameters are deprecated. "
+                        "Use COMPONENT instead to name runtime files. Development files are installed in the shared Development component.")
   endif()
 
   # Parse function arguments
@@ -818,7 +815,7 @@ function(target_prepare_package TARGET_NAME)
   endif()
   list(REMOVE_DUPLICATES EXISTING_TARGETS)
 
-  # Store per-target component configuration Component logic: if COMPONENT is set, use it; otherwise use default Runtime/Development
+  # Store per-target component configuration. COMPONENT names runtime files only; SDK files are always part of the shared Development component.
   get_property(
     _tip_existing_alias_name_set GLOBAL
     PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_ALIAS_NAME"
@@ -859,11 +856,10 @@ function(target_prepare_package TARGET_NAME)
 
   if(ARG_COMPONENT)
     set(RUNTIME_COMPONENT_NAME "${ARG_COMPONENT}")
-    set(DEVELOPMENT_COMPONENT_NAME "${ARG_COMPONENT}_Development")
   else()
     set(RUNTIME_COMPONENT_NAME "Runtime")
-    set(DEVELOPMENT_COMPONENT_NAME "Development")
   endif()
+  set(DEVELOPMENT_COMPONENT_NAME "Development")
 
   set_property(GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_RUNTIME_COMPONENT" "${RUNTIME_COMPONENT_NAME}")
   set_property(GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_DEVELOPMENT_COMPONENT" "${DEVELOPMENT_COMPONENT_NAME}")
@@ -1045,7 +1041,7 @@ function(target_prepare_package TARGET_NAME)
     set_property(GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_CURRENT_BINARY_DIR" "${CMAKE_CURRENT_BINARY_DIR}")
   endif()
 
-  # For config files, use the first target's development component as default
+  # For config files, use the shared development component for the export.
   get_property(EXISTING_CONFIG_COMPONENT GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_CONFIG_DEVELOPMENT_COMPONENT")
   if(NOT EXISTING_CONFIG_COMPONENT)
     set_property(GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_CONFIG_DEVELOPMENT_COMPONENT" "${DEVELOPMENT_COMPONENT_NAME}")
@@ -1207,23 +1203,19 @@ function(_collect_export_components EXPORT_PROPERTY_PREFIX TARGETS)
   set(COMPONENT_TARGET_MAP "")
 
   foreach(TARGET_NAME ${TARGETS})
-    get_property(TARGET_COMP GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_COMPONENT")
     get_property(TARGET_RUNTIME_COMP GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_RUNTIME_COMPONENT")
     get_property(TARGET_DEV_COMP GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_DEVELOPMENT_COMPONENT")
 
-    # Determine actual component names Priority: explicit components > prefix pattern > defaults
-
-    if(TARGET_RUNTIME_COMP AND NOT TARGET_COMP)
-      # Explicit components specified (deprecated mode) - should be caught by validation
+    # Prefer the canonical component names stored by target_prepare_package().
+    if(TARGET_RUNTIME_COMP)
       set(RUNTIME_COMPONENT_NAME "${TARGET_RUNTIME_COMP}")
-      set(DEV_COMPONENT_NAME "${TARGET_DEV_COMP}")
-    elseif(TARGET_COMP)
-      # NEW SCHEME: COMPONENT -> runtime, COMPONENT_Development -> development files
-      set(RUNTIME_COMPONENT_NAME "${TARGET_COMP}")
-      set(DEV_COMPONENT_NAME "${TARGET_COMP}_Development")
     else()
-      # Default components: Runtime, Development
       set(RUNTIME_COMPONENT_NAME "Runtime")
+    endif()
+
+    if(TARGET_DEV_COMP)
+      set(DEV_COMPONENT_NAME "${TARGET_DEV_COMP}")
+    else()
       set(DEV_COMPONENT_NAME "Development")
     endif()
 
@@ -1257,16 +1249,14 @@ function(_collect_export_components EXPORT_PROPERTY_PREFIX TARGETS)
 endfunction(_collect_export_components)
 
 # ~~~
-# Helper: Build CMake component arguments for install() commands using prefix pattern.
+# Helper: Build CMake component arguments for install() commands.
 #
-# This internal helper function generates component names using the Component Prefix Pattern:
-# - If COMPONENT_PREFIX is provided: "${COMPONENT_PREFIX}_${COMPONENT_TYPE}"
-# - If no prefix: "${COMPONENT_TYPE}" only
-# - Always single install (no dual install complexity)
+# This internal helper returns one COMPONENT argument for the requested component
+# name. COMPONENT_PREFIX is kept only for older internal callers.
 #
 # Parameters:
 #   VAR_PREFIX - Variable name prefix for the output arguments
-#   COMPONENT_PREFIX - Optional prefix for component names (e.g., "Core", "GUI")
+#   COMPONENT_PREFIX - Optional runtime component name (e.g., "Core", "GUI")
 #   COMPONENT_TYPE - Component type: "Runtime" or "Development"
 #
 # Returns via parent scope:
@@ -1283,9 +1273,8 @@ function(_build_component_args VAR_PREFIX COMPONENT_PREFIX COMPONENT_TYPE)
     return()
   endif()
 
-  # Generate component name using prefix pattern
-  if(COMPONENT_PREFIX)
-    set(COMPONENT_NAME "${COMPONENT_PREFIX}_${COMPONENT_TYPE}")
+  if(COMPONENT_PREFIX AND COMPONENT_TYPE STREQUAL "Runtime")
+    set(COMPONENT_NAME "${COMPONENT_PREFIX}")
   else()
     set(COMPONENT_NAME "${COMPONENT_TYPE}")
   endif()
@@ -1549,7 +1538,6 @@ function(finalize_package)
   foreach(TARGET_NAME ${TARGETS})
     get_property(TARGET_RUNTIME_COMP GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_RUNTIME_COMPONENT")
     get_property(TARGET_DEV_COMP GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_DEVELOPMENT_COMPONENT")
-    get_property(TARGET_COMP GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_COMPONENT")
     get_property(TARGET_ALIAS_NAME GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_ALIAS_NAME")
     get_property(TARGET_ALIAS_NAME_EXPLICIT GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_ALIAS_NAME_EXPLICIT")
 
@@ -1576,34 +1564,20 @@ function(finalize_package)
       list(APPEND _tip_cps_default_target_names "${TARGET_ALIAS_NAME}")
     endif()
 
-    # Build component args for this target Priority: explicit components > prefix pattern > defaults
-
-    if(TARGET_RUNTIME_COMP AND NOT TARGET_COMP)
-      # Explicit runtime component specified (traditional mode)
-      set(TARGET_RUNTIME_COMPONENT_ARGS COMPONENT ${TARGET_RUNTIME_COMP})
-    elseif(TARGET_COMP)
-      # NEW SCHEME: COMPONENT name directly for runtime files
-      set(TARGET_RUNTIME_COMPONENT_ARGS COMPONENT ${TARGET_COMP})
+    if(TARGET_RUNTIME_COMP)
+      set(TARGET_RUNTIME_COMPONENT_ARGS COMPONENT "${TARGET_RUNTIME_COMP}")
     else()
-      # Default: Runtime
       _build_component_args(TARGET_RUNTIME_COMPONENT "" "Runtime")
     endif()
 
-    if(TARGET_DEV_COMP AND NOT TARGET_COMP)
-      # Explicit development component specified (traditional mode)
-      set(TARGET_DEV_COMPONENT_ARGS COMPONENT ${TARGET_DEV_COMP})
-    elseif(TARGET_COMP)
-      # NEW SCHEME: COMPONENT_Development for development files
-      set(TARGET_DEV_COMPONENT_ARGS COMPONENT "${TARGET_COMP}_Development")
+    if(TARGET_DEV_COMP)
+      set(TARGET_DEV_COMPONENT_ARGS COMPONENT "${TARGET_DEV_COMP}")
     else()
-      # Default: Development
       _build_component_args(TARGET_DEV_COMPONENT "" "Development")
     endif()
 
-    if(TARGET_DEV_COMP AND NOT TARGET_COMP)
-      set(TARGET_NAMELINK_COMPONENT_ARGS NAMELINK_COMPONENT ${TARGET_DEV_COMP})
-    elseif(TARGET_COMP)
-      set(TARGET_NAMELINK_COMPONENT_ARGS NAMELINK_COMPONENT "${TARGET_COMP}_Development")
+    if(TARGET_DEV_COMP)
+      set(TARGET_NAMELINK_COMPONENT_ARGS NAMELINK_COMPONENT "${TARGET_DEV_COMP}")
     else()
       set(TARGET_NAMELINK_COMPONENT_ARGS NAMELINK_COMPONENT Development)
     endif()
@@ -1860,7 +1834,7 @@ function(finalize_package)
     endif()
   endforeach()
 
-  # Install CMake package metadata with every development component for this export. A selected SDK/development package must carry the config entry point.
+  # Install CMake package metadata with the shared SDK component for this export.
   set(CONFIG_COMPONENTS "")
   if(ALL_DEVELOPMENT_COMPONENTS)
     set(CONFIG_COMPONENTS ${ALL_DEVELOPMENT_COMPONENTS})

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -333,6 +333,59 @@ function(_tip_component_dependency_property_name OUT_VAR EXPORT_PROPERTY_PREFIX 
       PARENT_SCOPE)
 endfunction()
 
+function(_tip_cpack_component_dependency_property_name OUT_VAR COMPONENT_NAME)
+  string(SHA256 _tip_component_hash "${COMPONENT_NAME}")
+  set(${OUT_VAR}
+      "_TIP_CPACK_COMPONENT_DEPENDENCY_${_tip_component_hash}"
+      PARENT_SCOPE)
+endfunction()
+
+function(_tip_append_cpack_component_dependencies COMPONENT_NAME)
+  set(_tip_dependencies ${ARGN})
+  if(NOT _tip_dependencies)
+    return()
+  endif()
+
+  list(REMOVE_ITEM _tip_dependencies "${COMPONENT_NAME}")
+  list(REMOVE_DUPLICATES _tip_dependencies)
+  if(NOT _tip_dependencies)
+    return()
+  endif()
+
+  _tip_cpack_component_dependency_property_name(_tip_component_dependency_property "${COMPONENT_NAME}")
+  get_property(_tip_existing_dependencies GLOBAL PROPERTY "${_tip_component_dependency_property}")
+  set(_tip_updated_dependencies ${_tip_existing_dependencies} ${_tip_dependencies})
+  list(REMOVE_ITEM _tip_updated_dependencies "${COMPONENT_NAME}")
+  list(REMOVE_DUPLICATES _tip_updated_dependencies)
+  set_property(GLOBAL PROPERTY "${_tip_component_dependency_property}" "${_tip_updated_dependencies}")
+endfunction()
+
+function(_tip_find_package_expression_without_required OUT_VAR DEPENDENCY_EXPRESSION)
+  separate_arguments(_tip_dependency_args UNIX_COMMAND "${DEPENDENCY_EXPRESSION}")
+  set(_tip_optional_dependency_args "")
+
+  foreach(_tip_dependency_arg IN LISTS _tip_dependency_args)
+    string(TOUPPER "${_tip_dependency_arg}" _tip_dependency_arg_upper)
+    if(_tip_dependency_arg_upper STREQUAL "REQUIRED")
+      continue()
+    endif()
+    list(APPEND _tip_optional_dependency_args "${_tip_dependency_arg}")
+  endforeach()
+
+  string(JOIN " " _tip_optional_dependency_expression ${_tip_optional_dependency_args})
+  set(${OUT_VAR}
+      "${_tip_optional_dependency_expression}"
+      PARENT_SCOPE)
+endfunction()
+
+function(_tip_find_package_expression_package_name OUT_VAR DEPENDENCY_EXPRESSION)
+  separate_arguments(_tip_dependency_args UNIX_COMMAND "${DEPENDENCY_EXPRESSION}")
+  list(GET _tip_dependency_args 0 _tip_dependency_package_name)
+  set(${OUT_VAR}
+      "${_tip_dependency_package_name}"
+      PARENT_SCOPE)
+endfunction()
+
 # ~~~
 # Prepare a CMake installation target for packaging.
 #
@@ -1468,6 +1521,14 @@ function(finalize_package)
     project_log(VERBOSE "Export '${ARG_EXPORT_NAME}' finalizing ${target_count} ${target_label}: [${TARGETS}]")
   endif()
 
+  set(_tip_export_target_components ${ALL_RUNTIME_COMPONENTS} ${ALL_DEVELOPMENT_COMPONENTS})
+  if(_tip_export_target_components)
+    list(REMOVE_DUPLICATES _tip_export_target_components)
+    foreach(_tip_development_component IN LISTS ALL_DEVELOPMENT_COMPONENTS)
+      _tip_append_cpack_component_dependencies("${_tip_development_component}" ${_tip_export_target_components})
+    endforeach()
+  endif()
+
   # Apply DEBUG_POSTFIX only to library targets if specified
   if(DEBUG_POSTFIX)
     foreach(TARGET_NAME ${TARGETS})
@@ -1539,6 +1600,14 @@ function(finalize_package)
       _build_component_args(TARGET_DEV_COMPONENT "" "Development")
     endif()
 
+    if(TARGET_DEV_COMP AND NOT TARGET_COMP)
+      set(TARGET_NAMELINK_COMPONENT_ARGS NAMELINK_COMPONENT ${TARGET_DEV_COMP})
+    elseif(TARGET_COMP)
+      set(TARGET_NAMELINK_COMPONENT_ARGS NAMELINK_COMPONENT "${TARGET_COMP}_Development")
+    else()
+      set(TARGET_NAMELINK_COMPONENT_ARGS NAMELINK_COMPONENT Development)
+    endif()
+
     # Set the export name for the target if different from target name
     if(NOT TARGET_ALIAS_NAME STREQUAL TARGET_NAME)
       set_property(TARGET ${TARGET_NAME} PROPERTY EXPORT_NAME ${TARGET_ALIAS_NAME})
@@ -1582,6 +1651,7 @@ function(finalize_package)
       DESTINATION
       "${_tip_cfgdir}${CMAKE_INSTALL_LIBDIR}"
       ${TARGET_RUNTIME_COMPONENT_ARGS}
+      ${TARGET_NAMELINK_COMPONENT_ARGS}
       ARCHIVE
       DESTINATION
       "${_tip_cfgdir}${CMAKE_INSTALL_LIBDIR}"
@@ -1790,22 +1860,26 @@ function(finalize_package)
     endif()
   endforeach()
 
-  # Set up component args for config files using the first development component
+  # Install CMake package metadata with every development component for this export. A selected SDK/development package must carry the config entry point.
+  set(CONFIG_COMPONENTS "")
   if(ALL_DEVELOPMENT_COMPONENTS)
-    list(GET ALL_DEVELOPMENT_COMPONENTS 0 FIRST_DEV_COMPONENT)
-    set(CONFIG_COMPONENT_ARGS COMPONENT ${FIRST_DEV_COMPONENT})
+    set(CONFIG_COMPONENTS ${ALL_DEVELOPMENT_COMPONENTS})
   else()
-    # Fallback to generic Development component
-    _build_component_args(CONFIG_COMPONENT "" "Development")
+    set(CONFIG_COMPONENTS Development)
   endif()
+  list(REMOVE_DUPLICATES CONFIG_COMPONENTS)
+  list(GET CONFIG_COMPONENTS 0 FIRST_CONFIG_COMPONENT)
+  set(CONFIG_COMPONENT_ARGS COMPONENT ${FIRST_CONFIG_COMPONENT})
 
   # Install targets export file with config component CMake automatically handles configuration-specific exports
-  install(
-    EXPORT ${ARG_EXPORT_NAME}
-    FILE ${ARG_EXPORT_NAME}Targets.cmake
-    NAMESPACE ${NAMESPACE}
-    DESTINATION ${CMAKE_CONFIG_DESTINATION}
-    ${CONFIG_COMPONENT_ARGS})
+  foreach(_tip_config_component IN LISTS CONFIG_COMPONENTS)
+    install(
+      EXPORT ${ARG_EXPORT_NAME}
+      FILE ${ARG_EXPORT_NAME}Targets.cmake
+      NAMESPACE ${NAMESPACE}
+      DESTINATION ${CMAKE_CONFIG_DESTINATION}
+      COMPONENT "${_tip_config_component}")
+  endforeach()
 
   if(SBOM_ENABLED)
     set(CMAKE_EXPERIMENTAL_GENERATE_SBOM "${SBOM_EXPERIMENTAL_VALUE}")
@@ -2062,7 +2136,16 @@ function(finalize_package)
 
       set(_tip_component_dep_list ${component_deps})
       foreach(component_dep IN LISTS _tip_component_dep_list)
-        string(APPEND PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "  find_dependency(${component_dep})\n")
+        _tip_find_package_expression_package_name(_tip_component_dep_package_name "${component_dep}")
+        _tip_find_package_expression_without_required(_tip_component_dep_optional_expression "${component_dep}")
+        string(APPEND PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "  if(${ARG_EXPORT_NAME}_FIND_REQUIRED_${component_name})\n")
+        string(APPEND PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "    find_dependency(${component_dep})\n")
+        string(APPEND PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "  else()\n")
+        string(APPEND PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "    find_package(${_tip_component_dep_optional_expression} QUIET)\n")
+        string(APPEND PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "    if(NOT ${_tip_component_dep_package_name}_FOUND)\n")
+        string(APPEND PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "      set(${ARG_EXPORT_NAME}_${component_name}_FOUND FALSE)\n")
+        string(APPEND PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "    endif()\n")
+        string(APPEND PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "  endif()\n")
       endforeach()
 
       string(APPEND PACKAGE_COMPONENT_DEPENDENCIES_CONTENT "endif()\n")
@@ -2140,10 +2223,12 @@ function(finalize_package)
     PATH_VARS CMAKE_INSTALL_PREFIX)
 
   # Install config files using correct filename with config component
-  install(
-    FILES "${CURRENT_BINARY_DIR}/${CONFIG_FILENAME}" "${VERSION_FILE_PATH}" "${LEGACY_VERSION_FILE_PATH}"
-    DESTINATION ${CMAKE_CONFIG_DESTINATION}
-    ${CONFIG_COMPONENT_ARGS})
+  foreach(_tip_config_component IN LISTS CONFIG_COMPONENTS)
+    install(
+      FILES "${CURRENT_BINARY_DIR}/${CONFIG_FILENAME}" "${VERSION_FILE_PATH}" "${LEGACY_VERSION_FILE_PATH}"
+      DESTINATION ${CMAKE_CONFIG_DESTINATION}
+      COMPONENT "${_tip_config_component}")
+  endforeach()
 
   # Log package status with component information
   if(ALL_UNIQUE_COMPONENTS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -280,6 +280,12 @@ if(target_install_package_BUILD_PROOF_TESTS)
   add_test(NAME proof_component_find_package COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_component_find_package_test.cmake")
   set_tests_properties(proof_component_find_package PROPERTIES LABELS "proof;review")
 
+  add_test(NAME proof_cpack_component_metadata COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_cpack_component_metadata_test.cmake")
+  set_tests_properties(proof_cpack_component_metadata PROPERTIES LABELS "proof;review;cpack")
+
+  add_test(NAME proof_namelink_component COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_namelink_component_test.cmake")
+  set_tests_properties(proof_namelink_component PROPERTIES LABELS "proof;review")
+
   add_test(NAME proof_substitution_mode_variables COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_substitution_mode_variables_test.cmake")
   set_tests_properties(proof_substitution_mode_variables PROPERTIES LABELS "proof;review")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,7 +188,7 @@ endforeach()
 
 foreach(_tip_layout IN ITEMS split_debug split_all)
   add_test(NAME "install_layout_${_tip_layout}_release" COMMAND ${CMAKE_COMMAND} "-DTIP_LAYOUT=${_tip_layout}" "-DTIP_LAYOUT_TEST_CONFIG=Release" ${_tip_layout_test_common_args} -P
-                                                                  "${_tip_layout_test_script}")
+                                                                "${_tip_layout_test_script}")
   set_tests_properties("install_layout_${_tip_layout}_release" PROPERTIES LABELS "install-layout")
 endforeach()
 
@@ -198,9 +198,9 @@ foreach(_tip_middle_config IN ITEMS RelWithDebInfo MinSizeRel)
                                                                          "${_tip_layout_test_script}")
   set_tests_properties("install_layout_fhs_${_tip_middle_config_lower}" PROPERTIES LABELS "install-layout")
 
-  add_test(NAME "install_layout_fhs_release_consumed_by_${_tip_middle_config_lower}" COMMAND ${CMAKE_COMMAND} "-DTIP_LAYOUT=fhs" "-DTIP_LAYOUT_TEST_CONFIG=Release"
-                                                                                       "-DTIP_LAYOUT_CONSUMER_CONFIG=${_tip_middle_config}" ${_tip_layout_test_common_args} -P
-                                                                                       "${_tip_layout_test_script}")
+  add_test(NAME "install_layout_fhs_release_consumed_by_${_tip_middle_config_lower}"
+           COMMAND ${CMAKE_COMMAND} "-DTIP_LAYOUT=fhs" "-DTIP_LAYOUT_TEST_CONFIG=Release" "-DTIP_LAYOUT_CONSUMER_CONFIG=${_tip_middle_config}" ${_tip_layout_test_common_args} -P
+                   "${_tip_layout_test_script}")
   set_tests_properties("install_layout_fhs_release_consumed_by_${_tip_middle_config_lower}" PROPERTIES LABELS "install-layout;import-config-mapping")
 endforeach()
 
@@ -234,9 +234,9 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
   set(_tip_installed_consumer_main_install_config "${CMAKE_BUILD_TYPE}")
 endif()
 
-add_test(NAME installed_target_install_package_consumer COMMAND ${CMAKE_COMMAND} "-DTIP_REPO_ROOT=${_tip_repo_root}" "-DTIP_MAIN_BUILD_DIR=${CMAKE_BINARY_DIR}"
-                                                                "-DTIP_MAIN_INSTALL_CONFIG=${_tip_installed_consumer_main_install_config}"
-                                                                "-DTIP_CONSUMER_TEST_ROOT=${_tip_installed_consumer_test_root}" ${_tip_layout_test_common_args} -P "${_tip_installed_consumer_script}")
+add_test(NAME installed_target_install_package_consumer
+         COMMAND ${CMAKE_COMMAND} "-DTIP_REPO_ROOT=${_tip_repo_root}" "-DTIP_MAIN_BUILD_DIR=${CMAKE_BINARY_DIR}" "-DTIP_MAIN_INSTALL_CONFIG=${_tip_installed_consumer_main_install_config}"
+                 "-DTIP_CONSUMER_TEST_ROOT=${_tip_installed_consumer_test_root}" ${_tip_layout_test_common_args} -P "${_tip_installed_consumer_script}")
 set_tests_properties(installed_target_install_package_consumer PROPERTIES LABELS "consumer;install")
 
 option(target_install_package_BUILD_PROOF_TESTS "Enable proof tests for known review findings" ON)
@@ -283,6 +283,9 @@ if(target_install_package_BUILD_PROOF_TESTS)
   add_test(NAME proof_cpack_component_metadata COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_cpack_component_metadata_test.cmake")
   set_tests_properties(proof_cpack_component_metadata PROPERTIES LABELS "proof;review;cpack")
 
+  add_test(NAME proof_cpack_single_component_filter COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_cpack_single_component_filter_test.cmake")
+  set_tests_properties(proof_cpack_single_component_filter PROPERTIES LABELS "proof;review;cpack")
+
   add_test(NAME proof_namelink_component COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_namelink_component_test.cmake")
   set_tests_properties(proof_namelink_component PROPERTIES LABELS "proof;review")
 
@@ -303,6 +306,9 @@ if(target_install_package_BUILD_PROOF_TESTS)
 
   add_test(NAME proof_unknown_arguments COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_unknown_arguments_test.cmake")
   set_tests_properties(proof_unknown_arguments PROPERTIES LABELS "proof;review")
+
+  add_test(NAME proof_export_alias_conflict COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_export_alias_conflict_test.cmake")
+  set_tests_properties(proof_export_alias_conflict PROPERTIES LABELS "proof;review")
 
   if(UNIX)
     add_test(NAME proof_gpg_signing_methods COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_gpg_signing_methods_test.cmake")

--- a/tests/cmake/proof_additional_targets_components_test.cmake
+++ b/tests/cmake/proof_additional_targets_components_test.cmake
@@ -52,7 +52,7 @@ _tip_proof_run_step(
   Release)
 _tip_proof_run_step(
   NAME
-  "fixture-install-core-development"
+  "fixture-install-development"
   COMMAND
   "${CMAKE_COMMAND}"
   --install
@@ -62,7 +62,7 @@ _tip_proof_run_step(
   --prefix
   "${_tip_install_prefix}"
   --component
-  Core_Development)
+  Development)
 
 file(
   WRITE "${_tip_consumer_source_dir}/CMakeLists.txt"

--- a/tests/cmake/proof_component_find_package_test.cmake
+++ b/tests/cmake/proof_component_find_package_test.cmake
@@ -19,6 +19,13 @@ set(_tip_bad_template_source_dir "${_tip_case_root}/bad-template-src")
 set(_tip_bad_template_build_dir "${_tip_case_root}/bad-template-build")
 set(_tip_valid_bare_deps_source_dir "${_tip_case_root}/valid-bare-deps-src")
 set(_tip_valid_bare_deps_build_dir "${_tip_case_root}/valid-bare-deps-build")
+set(_tip_optional_deps_source_dir "${_tip_case_root}/optional-deps-src")
+set(_tip_optional_deps_build_dir "${_tip_case_root}/optional-deps-build")
+set(_tip_optional_deps_install_prefix "${_tip_case_root}/optional-deps-install")
+set(_tip_optional_consumer_source_dir "${_tip_case_root}/optional-consumer-src")
+set(_tip_optional_consumer_build_dir "${_tip_case_root}/optional-consumer-build")
+set(_tip_required_consumer_source_dir "${_tip_case_root}/required-consumer-src")
+set(_tip_required_consumer_build_dir "${_tip_case_root}/required-consumer-build")
 set(_tip_ambiguous_deps_source_dir "${_tip_case_root}/ambiguous-deps-src")
 set(_tip_ambiguous_deps_build_dir "${_tip_case_root}/ambiguous-deps-build")
 set(_tip_legacy_semicolon_deps_source_dir "${_tip_case_root}/legacy-semicolon-deps-src")
@@ -29,6 +36,9 @@ file(MAKE_DIRECTORY "${_tip_fixture_source_dir}/src")
 file(MAKE_DIRECTORY "${_tip_consumer_source_dir}")
 file(MAKE_DIRECTORY "${_tip_bad_template_source_dir}/src")
 file(MAKE_DIRECTORY "${_tip_valid_bare_deps_source_dir}/src")
+file(MAKE_DIRECTORY "${_tip_optional_deps_source_dir}")
+file(MAKE_DIRECTORY "${_tip_optional_consumer_source_dir}")
+file(MAKE_DIRECTORY "${_tip_required_consumer_source_dir}")
 file(MAKE_DIRECTORY "${_tip_ambiguous_deps_source_dir}/src")
 file(MAKE_DIRECTORY "${_tip_legacy_semicolon_deps_source_dir}/src")
 
@@ -130,6 +140,45 @@ _tip_proof_assert_file_contains("${_tip_valid_bare_deps_build_dir}/proof_valid_b
 _tip_proof_assert_file_contains("${_tip_valid_bare_deps_build_dir}/proof_valid_bare_deps_pkgConfig.cmake" "find_dependency(glfw3 CONFIG REQUIRED)")
 _tip_proof_assert_file_contains("${_tip_valid_bare_deps_build_dir}/proof_valid_bare_deps_pkgConfig.cmake" "if(\"Optional\" IN_LIST proof_valid_bare_deps_pkg_FIND_COMPONENTS)")
 _tip_proof_assert_file_contains("${_tip_valid_bare_deps_build_dir}/proof_valid_bare_deps_pkgConfig.cmake" "if(\"Config\" IN_LIST proof_valid_bare_deps_pkg_FIND_COMPONENTS)")
+
+file(
+  WRITE "${_tip_optional_deps_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 3.25)\n" "project(proof_component_optional_deps VERSION 1.0.0 LANGUAGES CXX)\n" "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n" "add_library(proof_optional_deps_lib INTERFACE)\n"
+  "target_install_package(proof_optional_deps_lib EXPORT_NAME proof_optional_deps_pkg COMPONENT_DEPENDENCIES Gui \"DefinitelyMissingTipPkgForOptionalComponents REQUIRED\")\n")
+
+set(_tip_optional_deps_configure_command "${CMAKE_COMMAND}" -S "${_tip_optional_deps_source_dir}" -B "${_tip_optional_deps_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
+
+_tip_proof_run_step(NAME "optional-component-dependencies-configure" COMMAND ${_tip_optional_deps_configure_command})
+_tip_proof_run_step(
+  NAME
+  "optional-component-dependencies-install"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --install
+  "${_tip_optional_deps_build_dir}"
+  --config
+  Release
+  --prefix
+  "${_tip_optional_deps_install_prefix}")
+_tip_proof_assert_file_contains("${_tip_optional_deps_install_prefix}/share/cmake/proof_optional_deps_pkg/proof_optional_deps_pkgConfig.cmake"
+                                "find_package(DefinitelyMissingTipPkgForOptionalComponents QUIET)")
+
+file(
+  WRITE "${_tip_optional_consumer_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 3.25)\n" "project(proof_optional_component_consumer LANGUAGES CXX)\n"
+  "find_package(proof_optional_deps_pkg CONFIG REQUIRED OPTIONAL_COMPONENTS Gui PATHS \"${_tip_optional_deps_install_prefix}\" NO_DEFAULT_PATH)\n" "if(proof_optional_deps_pkg_Gui_FOUND)\n"
+  "  message(FATAL_ERROR \"Optional Gui component should be marked missing when its dependency is absent\")\n" "endif()\n")
+
+set(_tip_optional_consumer_configure_command "${CMAKE_COMMAND}" -S "${_tip_optional_consumer_source_dir}" -B "${_tip_optional_consumer_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
+_tip_proof_run_step(NAME "optional-component-consumer-configure" COMMAND ${_tip_optional_consumer_configure_command})
+
+file(WRITE "${_tip_required_consumer_source_dir}/CMakeLists.txt"
+     "cmake_minimum_required(VERSION 3.25)\n" "project(proof_required_component_consumer LANGUAGES CXX)\n"
+     "find_package(proof_optional_deps_pkg CONFIG REQUIRED COMPONENTS Gui PATHS \"${_tip_optional_deps_install_prefix}\" NO_DEFAULT_PATH)\n")
+
+set(_tip_required_consumer_configure_command "${CMAKE_COMMAND}" -S "${_tip_required_consumer_source_dir}" -B "${_tip_required_consumer_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
+_tip_proof_expect_failure(NAME "required-component-consumer-configure" COMMAND ${_tip_required_consumer_configure_command} EXPECT_CONTAINS "DefinitelyMissingTipPkgForOptionalComponents")
 
 file(
   WRITE "${_tip_ambiguous_deps_source_dir}/CMakeLists.txt"

--- a/tests/cmake/proof_cpack_component_metadata_test.cmake
+++ b/tests/cmake/proof_cpack_component_metadata_test.cmake
@@ -31,11 +31,13 @@ file(
   "add_library(proof_storage STATIC src/storage.cpp)\n"
   "target_link_libraries(proof_storage PUBLIC proof_core)\n"
   "target_compile_features(proof_storage PUBLIC cxx_std_17)\n"
-  "target_install_package(proof_core EXPORT_NAME proof_cpack_component_pkg NAMESPACE Proof:: COMPONENT Core)\n"
+  "target_install_package(proof_core EXPORT_NAME proof_cpack_component_pkg NAMESPACE Proof:: COMPONENT Core INCLUDE_ON_FIND_PACKAGE cmake/proof-extra.cmake)\n"
   "target_install_package(proof_storage EXPORT_NAME proof_cpack_component_pkg NAMESPACE Proof:: COMPONENT Storage)\n")
 
+file(MAKE_DIRECTORY "${_tip_fixture_source_dir}/cmake")
 file(WRITE "${_tip_fixture_source_dir}/src/core.cpp" "int proof_core_value() { return 41; }\n")
 file(WRITE "${_tip_fixture_source_dir}/src/storage.cpp" "int proof_core_value(); int proof_storage_value() { return proof_core_value() + 1; }\n")
+file(WRITE "${_tip_fixture_source_dir}/cmake/proof-extra.cmake" "set(proof_cpack_component_pkg_EXTRA_INCLUDED TRUE)\n")
 
 set(_tip_fixture_configure_command "${CMAKE_COMMAND}" -S "${_tip_fixture_source_dir}" -B "${_tip_fixture_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
 
@@ -64,7 +66,10 @@ _tip_proof_run_step(
   Storage_Development)
 
 set(_tip_config_file "${_tip_install_prefix}/share/cmake/proof_cpack_component_pkg/proof_cpack_component_pkgConfig.cmake")
+set(_tip_extra_file "${_tip_install_prefix}/share/cmake/proof_cpack_component_pkg/proof-extra.cmake")
 _tip_proof_assert_exists("${_tip_config_file}")
+_tip_proof_assert_exists("${_tip_extra_file}")
+_tip_proof_assert_file_contains("${_tip_config_file}" "proof-extra.cmake")
 
 set(_tip_cpack_config_file "${_tip_fixture_build_dir}/CPackConfig.cmake")
 _tip_proof_assert_exists("${_tip_cpack_config_file}")

--- a/tests/cmake/proof_cpack_component_metadata_test.cmake
+++ b/tests/cmake/proof_cpack_component_metadata_test.cmake
@@ -8,11 +8,15 @@ endif()
 if(NOT DEFINED TIP_PROOF_TEST_ROOT)
   _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
 endif()
+if(NOT CMAKE_CPACK_COMMAND)
+  _tip_proof_fail("CMAKE_CPACK_COMMAND is required")
+endif()
 
 set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/cpack-component-metadata")
 set(_tip_fixture_source_dir "${_tip_case_root}/fixture-src")
 set(_tip_fixture_build_dir "${_tip_case_root}/fixture-build")
 set(_tip_install_prefix "${_tip_case_root}/fixture-install")
+set(_tip_package_dir "${_tip_case_root}/packages")
 
 file(REMOVE_RECURSE "${_tip_case_root}")
 file(MAKE_DIRECTORY "${_tip_fixture_source_dir}/src")
@@ -26,18 +30,28 @@ file(
   "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
   "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
   "export_cpack(PACKAGE_NAME ProofCpackComponents PACKAGE_VERSION 1.0.0 GENERATORS TGZ NO_DEFAULT_GENERATORS)\n"
-  "add_library(proof_core STATIC src/core.cpp)\n"
+  "add_library(proof_core SHARED src/core.cpp)\n"
+  "set_target_properties(proof_core PROPERTIES VERSION \${PROJECT_VERSION} SOVERSION \${PROJECT_VERSION_MAJOR})\n"
   "target_compile_features(proof_core PUBLIC cxx_std_17)\n"
-  "add_library(proof_storage STATIC src/storage.cpp)\n"
+  "add_library(proof_storage SHARED src/storage.cpp)\n"
+  "set_target_properties(proof_storage PROPERTIES VERSION \${PROJECT_VERSION} SOVERSION \${PROJECT_VERSION_MAJOR})\n"
   "target_link_libraries(proof_storage PUBLIC proof_core)\n"
   "target_compile_features(proof_storage PUBLIC cxx_std_17)\n"
-  "target_install_package(proof_core EXPORT_NAME proof_cpack_component_pkg NAMESPACE Proof:: COMPONENT Core INCLUDE_ON_FIND_PACKAGE cmake/proof-extra.cmake)\n"
-  "target_install_package(proof_storage EXPORT_NAME proof_cpack_component_pkg NAMESPACE Proof:: COMPONENT Storage)\n")
+  "add_library(proof_sdk STATIC src/sdk.cpp)\n"
+  "target_compile_features(proof_sdk PUBLIC cxx_std_17)\n"
+  "if(WIN32)\n"
+  "  set_target_properties(proof_core proof_storage PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)\n"
+  "endif()\n"
+  "target_install_package(proof_core EXPORT_NAME proof_cpack_component_pkg NAMESPACE Proof:: COMPONENT Core INCLUDE_ON_FIND_PACKAGE cmake/proof-extra.cmake ADDITIONAL_FILES cmake/proof-doc.txt ADDITIONAL_FILES_COMPONENTS Documentation)\n"
+  "target_install_package(proof_storage EXPORT_NAME proof_cpack_component_pkg NAMESPACE Proof:: COMPONENT Storage)\n"
+  "target_install_package(proof_sdk EXPORT_NAME proof_cpack_component_pkg NAMESPACE Proof:: COMPONENT SdkOnly)\n")
 
 file(MAKE_DIRECTORY "${_tip_fixture_source_dir}/cmake")
 file(WRITE "${_tip_fixture_source_dir}/src/core.cpp" "int proof_core_value() { return 41; }\n")
 file(WRITE "${_tip_fixture_source_dir}/src/storage.cpp" "int proof_core_value(); int proof_storage_value() { return proof_core_value() + 1; }\n")
+file(WRITE "${_tip_fixture_source_dir}/src/sdk.cpp" "int proof_sdk_value() { return 43; }\n")
 file(WRITE "${_tip_fixture_source_dir}/cmake/proof-extra.cmake" "set(proof_cpack_component_pkg_EXTRA_INCLUDED TRUE)\n")
+file(WRITE "${_tip_fixture_source_dir}/cmake/proof-doc.txt" "Proof documentation\n")
 
 set(_tip_fixture_configure_command "${CMAKE_COMMAND}" -S "${_tip_fixture_source_dir}" -B "${_tip_fixture_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
 
@@ -71,33 +85,34 @@ _tip_proof_assert_exists("${_tip_config_file}")
 _tip_proof_assert_exists("${_tip_extra_file}")
 _tip_proof_assert_file_contains("${_tip_config_file}" "proof-extra.cmake")
 
-file(GLOB _tip_core_libraries "${_tip_install_prefix}/lib*/*proof_core*")
-if(NOT _tip_core_libraries)
-  _tip_proof_fail("Expected the unified Development component to install proof_core development artifacts")
-endif()
-
-file(GLOB _tip_storage_libraries "${_tip_install_prefix}/lib*/*proof_storage*")
-if(NOT _tip_storage_libraries)
-  _tip_proof_fail("Expected the unified Development component to install proof_storage development artifacts")
+file(GLOB _tip_sdk_libraries "${_tip_install_prefix}/lib*/*proof_sdk*")
+if(NOT _tip_sdk_libraries)
+  _tip_proof_fail("Expected the unified Development component to install proof_sdk development artifacts")
 endif()
 
 set(_tip_cpack_config_file "${_tip_fixture_build_dir}/CPackConfig.cmake")
 _tip_proof_assert_exists("${_tip_cpack_config_file}")
 file(READ "${_tip_cpack_config_file}" _tip_cpack_config_content)
 
-foreach(_tip_expected_component IN ITEMS Core Storage Development)
+foreach(_tip_expected_component IN ITEMS Core Storage Development Documentation)
   string(FIND "${_tip_cpack_config_content}" "${_tip_expected_component}" _tip_component_index)
   if(_tip_component_index EQUAL -1)
     _tip_proof_fail("Expected CPackConfig.cmake to contain auto-detected component '${_tip_expected_component}'")
   endif()
 endforeach()
 
-foreach(_tip_unexpected_component IN ITEMS Core_Development Storage_Development)
+foreach(_tip_unexpected_component IN ITEMS SdkOnly Core_Development Storage_Development)
   string(FIND "${_tip_cpack_config_content}" "${_tip_unexpected_component}" _tip_component_index)
   if(NOT _tip_component_index EQUAL -1)
     _tip_proof_fail("Did not expect CPackConfig.cmake to contain legacy split SDK component '${_tip_unexpected_component}'")
   endif()
 endforeach()
+
+_tip_proof_assert_file_not_contains("${_tip_cpack_config_file}" "CPACK_COMPONENTS_DEFAULT")
+_tip_proof_assert_file_contains("${_tip_cpack_config_file}" "CPACK_COMPONENT_DEVELOPMENT_DISABLED \"TRUE\"")
+_tip_proof_assert_file_contains("${_tip_cpack_config_file}" "CPACK_COMPONENT_DOCUMENTATION_DISABLED \"TRUE\"")
+_tip_proof_assert_file_not_contains("${_tip_cpack_config_file}" "CPACK_COMPONENT_CORE_DISABLED \"TRUE\"")
+_tip_proof_assert_file_not_contains("${_tip_cpack_config_file}" "CPACK_COMPONENT_STORAGE_DISABLED \"TRUE\"")
 
 string(REGEX MATCH "set\\(CPACK_COMPONENT_DEVELOPMENT_DEPENDS \"([^\"]*)\"\\)" _tip_development_dep_match "${_tip_cpack_config_content}")
 if(NOT _tip_development_dep_match)
@@ -110,5 +125,89 @@ foreach(_tip_expected_dependency IN ITEMS Core Storage)
     _tip_proof_fail("Expected Development to depend on '${_tip_expected_dependency}', got: ${_tip_development_dependencies}")
   endif()
 endforeach()
+
+foreach(_tip_unexpected_dependency IN ITEMS SdkOnly Development)
+  if("${_tip_unexpected_dependency}" IN_LIST _tip_development_dependencies)
+    _tip_proof_fail("Did not expect Development to depend on '${_tip_unexpected_dependency}', got: ${_tip_development_dependencies}")
+  endif()
+endforeach()
+
+_tip_proof_run_step(
+  NAME
+  "fixture-cpack-tgz"
+  COMMAND
+  "${CMAKE_CPACK_COMMAND}"
+  -G
+  TGZ
+  --config
+  "${_tip_cpack_config_file}"
+  -B
+  "${_tip_package_dir}")
+
+foreach(_tip_component IN ITEMS Core Storage Development Documentation)
+  file(GLOB _tip_${_tip_component}_archives "${_tip_package_dir}/*-${_tip_component}.tar.gz")
+  list(LENGTH _tip_${_tip_component}_archives _tip_${_tip_component}_archive_count)
+  if(NOT _tip_${_tip_component}_archive_count EQUAL 1)
+    _tip_proof_fail("Expected exactly one ${_tip_component} archive, got ${_tip_${_tip_component}_archive_count}: ${_tip_${_tip_component}_archives}")
+  endif()
+endforeach()
+
+file(GLOB _tip_unexpected_sdk_archives "${_tip_package_dir}/*-SdkOnly.tar.gz")
+if(_tip_unexpected_sdk_archives)
+  _tip_proof_fail("Static-only target should not generate an empty SdkOnly runtime archive: ${_tip_unexpected_sdk_archives}")
+endif()
+
+foreach(_tip_runtime_component IN ITEMS Core Storage)
+  list(GET _tip_${_tip_runtime_component}_archives 0 _tip_runtime_archive)
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E tar tf "${_tip_runtime_archive}"
+    RESULT_VARIABLE _tip_tar_result
+    OUTPUT_VARIABLE _tip_runtime_archive_contents
+    ERROR_VARIABLE _tip_tar_error)
+  if(NOT _tip_tar_result EQUAL 0)
+    _tip_proof_fail("Failed to list ${_tip_runtime_component} archive: ${_tip_tar_error}")
+  endif()
+  string(TOLOWER "${_tip_runtime_component}" _tip_runtime_component_lower)
+  string(FIND "${_tip_runtime_archive_contents}" "proof_${_tip_runtime_component_lower}" _tip_runtime_payload_index)
+  if(_tip_runtime_payload_index EQUAL -1)
+    _tip_proof_fail("Expected ${_tip_runtime_component} archive to contain its runtime payload")
+  endif()
+  foreach(_tip_unexpected_entry IN ITEMS "share/cmake" "proof_sdk" "proof-extra.cmake")
+    string(FIND "${_tip_runtime_archive_contents}" "${_tip_unexpected_entry}" _tip_unexpected_entry_index)
+    if(NOT _tip_unexpected_entry_index EQUAL -1)
+      _tip_proof_fail("Did not expect ${_tip_runtime_component} archive to contain SDK entry '${_tip_unexpected_entry}'")
+    endif()
+  endforeach()
+endforeach()
+
+list(GET _tip_Development_archives 0 _tip_development_archive)
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" -E tar tf "${_tip_development_archive}"
+  RESULT_VARIABLE _tip_tar_result
+  OUTPUT_VARIABLE _tip_development_archive_contents
+  ERROR_VARIABLE _tip_tar_error)
+if(NOT _tip_tar_result EQUAL 0)
+  _tip_proof_fail("Failed to list Development archive: ${_tip_tar_error}")
+endif()
+foreach(_tip_expected_entry IN ITEMS "share/cmake/proof_cpack_component_pkg" "proof-extra.cmake" "proof_sdk")
+  string(FIND "${_tip_development_archive_contents}" "${_tip_expected_entry}" _tip_expected_entry_index)
+  if(_tip_expected_entry_index EQUAL -1)
+    _tip_proof_fail("Expected Development archive to contain '${_tip_expected_entry}'")
+  endif()
+endforeach()
+
+list(GET _tip_Documentation_archives 0 _tip_documentation_archive)
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" -E tar tf "${_tip_documentation_archive}"
+  RESULT_VARIABLE _tip_tar_result
+  OUTPUT_VARIABLE _tip_documentation_archive_contents
+  ERROR_VARIABLE _tip_tar_error)
+if(NOT _tip_tar_result EQUAL 0)
+  _tip_proof_fail("Failed to list Documentation archive: ${_tip_tar_error}")
+endif()
+string(FIND "${_tip_documentation_archive_contents}" "proof-doc.txt" _tip_doc_entry_index)
+if(_tip_doc_entry_index EQUAL -1)
+  _tip_proof_fail("Expected Documentation archive to contain proof-doc.txt")
+endif()
 
 message(STATUS "[proof] CPack component metadata proof passed.")

--- a/tests/cmake/proof_cpack_component_metadata_test.cmake
+++ b/tests/cmake/proof_cpack_component_metadata_test.cmake
@@ -53,7 +53,7 @@ _tip_proof_run_step(
   Release)
 _tip_proof_run_step(
   NAME
-  "fixture-install-storage-development"
+  "fixture-install-development"
   COMMAND
   "${CMAKE_COMMAND}"
   --install
@@ -63,7 +63,7 @@ _tip_proof_run_step(
   --prefix
   "${_tip_install_prefix}"
   --component
-  Storage_Development)
+  Development)
 
 set(_tip_config_file "${_tip_install_prefix}/share/cmake/proof_cpack_component_pkg/proof_cpack_component_pkgConfig.cmake")
 set(_tip_extra_file "${_tip_install_prefix}/share/cmake/proof_cpack_component_pkg/proof-extra.cmake")
@@ -71,26 +71,43 @@ _tip_proof_assert_exists("${_tip_config_file}")
 _tip_proof_assert_exists("${_tip_extra_file}")
 _tip_proof_assert_file_contains("${_tip_config_file}" "proof-extra.cmake")
 
+file(GLOB _tip_core_libraries "${_tip_install_prefix}/lib*/*proof_core*")
+if(NOT _tip_core_libraries)
+  _tip_proof_fail("Expected the unified Development component to install proof_core development artifacts")
+endif()
+
+file(GLOB _tip_storage_libraries "${_tip_install_prefix}/lib*/*proof_storage*")
+if(NOT _tip_storage_libraries)
+  _tip_proof_fail("Expected the unified Development component to install proof_storage development artifacts")
+endif()
+
 set(_tip_cpack_config_file "${_tip_fixture_build_dir}/CPackConfig.cmake")
 _tip_proof_assert_exists("${_tip_cpack_config_file}")
 file(READ "${_tip_cpack_config_file}" _tip_cpack_config_content)
 
-foreach(_tip_expected_component IN ITEMS Core Core_Development Storage Storage_Development)
+foreach(_tip_expected_component IN ITEMS Core Storage Development)
   string(FIND "${_tip_cpack_config_content}" "${_tip_expected_component}" _tip_component_index)
   if(_tip_component_index EQUAL -1)
     _tip_proof_fail("Expected CPackConfig.cmake to contain auto-detected component '${_tip_expected_component}'")
   endif()
 endforeach()
 
-string(REGEX MATCH "set\\(CPACK_COMPONENT_STORAGE_DEVELOPMENT_DEPENDS \"([^\"]*)\"\\)" _tip_storage_dep_match "${_tip_cpack_config_content}")
-if(NOT _tip_storage_dep_match)
-  _tip_proof_fail("Expected Storage_Development CPack dependency declaration")
+foreach(_tip_unexpected_component IN ITEMS Core_Development Storage_Development)
+  string(FIND "${_tip_cpack_config_content}" "${_tip_unexpected_component}" _tip_component_index)
+  if(NOT _tip_component_index EQUAL -1)
+    _tip_proof_fail("Did not expect CPackConfig.cmake to contain legacy split SDK component '${_tip_unexpected_component}'")
+  endif()
+endforeach()
+
+string(REGEX MATCH "set\\(CPACK_COMPONENT_DEVELOPMENT_DEPENDS \"([^\"]*)\"\\)" _tip_development_dep_match "${_tip_cpack_config_content}")
+if(NOT _tip_development_dep_match)
+  _tip_proof_fail("Expected Development CPack dependency declaration")
 endif()
 
-set(_tip_storage_dependencies "${CMAKE_MATCH_1}")
-foreach(_tip_expected_dependency IN ITEMS Storage Core Core_Development)
-  if(NOT "${_tip_expected_dependency}" IN_LIST _tip_storage_dependencies)
-    _tip_proof_fail("Expected Storage_Development to depend on '${_tip_expected_dependency}', got: ${_tip_storage_dependencies}")
+set(_tip_development_dependencies "${CMAKE_MATCH_1}")
+foreach(_tip_expected_dependency IN ITEMS Core Storage)
+  if(NOT "${_tip_expected_dependency}" IN_LIST _tip_development_dependencies)
+    _tip_proof_fail("Expected Development to depend on '${_tip_expected_dependency}', got: ${_tip_development_dependencies}")
   endif()
 endforeach()
 

--- a/tests/cmake/proof_cpack_component_metadata_test.cmake
+++ b/tests/cmake/proof_cpack_component_metadata_test.cmake
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 3.25)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/cpack-component-metadata")
+set(_tip_fixture_source_dir "${_tip_case_root}/fixture-src")
+set(_tip_fixture_build_dir "${_tip_case_root}/fixture-build")
+set(_tip_install_prefix "${_tip_case_root}/fixture-install")
+
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_fixture_source_dir}/src")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+
+file(
+  WRITE "${_tip_fixture_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 3.25)\n"
+  "project(proof_cpack_component_metadata VERSION 1.0.0 LANGUAGES CXX)\n"
+  "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+  "export_cpack(PACKAGE_NAME ProofCpackComponents PACKAGE_VERSION 1.0.0 GENERATORS TGZ NO_DEFAULT_GENERATORS)\n"
+  "add_library(proof_core STATIC src/core.cpp)\n"
+  "target_compile_features(proof_core PUBLIC cxx_std_17)\n"
+  "add_library(proof_storage STATIC src/storage.cpp)\n"
+  "target_link_libraries(proof_storage PUBLIC proof_core)\n"
+  "target_compile_features(proof_storage PUBLIC cxx_std_17)\n"
+  "target_install_package(proof_core EXPORT_NAME proof_cpack_component_pkg NAMESPACE Proof:: COMPONENT Core)\n"
+  "target_install_package(proof_storage EXPORT_NAME proof_cpack_component_pkg NAMESPACE Proof:: COMPONENT Storage)\n")
+
+file(WRITE "${_tip_fixture_source_dir}/src/core.cpp" "int proof_core_value() { return 41; }\n")
+file(WRITE "${_tip_fixture_source_dir}/src/storage.cpp" "int proof_core_value(); int proof_storage_value() { return proof_core_value() + 1; }\n")
+
+set(_tip_fixture_configure_command "${CMAKE_COMMAND}" -S "${_tip_fixture_source_dir}" -B "${_tip_fixture_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
+
+_tip_proof_run_step(NAME "fixture-configure" COMMAND ${_tip_fixture_configure_command})
+_tip_proof_run_step(
+  NAME
+  "fixture-build"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --build
+  "${_tip_fixture_build_dir}"
+  --config
+  Release)
+_tip_proof_run_step(
+  NAME
+  "fixture-install-storage-development"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --install
+  "${_tip_fixture_build_dir}"
+  --config
+  Release
+  --prefix
+  "${_tip_install_prefix}"
+  --component
+  Storage_Development)
+
+set(_tip_config_file "${_tip_install_prefix}/share/cmake/proof_cpack_component_pkg/proof_cpack_component_pkgConfig.cmake")
+_tip_proof_assert_exists("${_tip_config_file}")
+
+set(_tip_cpack_config_file "${_tip_fixture_build_dir}/CPackConfig.cmake")
+_tip_proof_assert_exists("${_tip_cpack_config_file}")
+file(READ "${_tip_cpack_config_file}" _tip_cpack_config_content)
+
+foreach(_tip_expected_component IN ITEMS Core Core_Development Storage Storage_Development)
+  string(FIND "${_tip_cpack_config_content}" "${_tip_expected_component}" _tip_component_index)
+  if(_tip_component_index EQUAL -1)
+    _tip_proof_fail("Expected CPackConfig.cmake to contain auto-detected component '${_tip_expected_component}'")
+  endif()
+endforeach()
+
+string(REGEX MATCH "set\\(CPACK_COMPONENT_STORAGE_DEVELOPMENT_DEPENDS \"([^\"]*)\"\\)" _tip_storage_dep_match "${_tip_cpack_config_content}")
+if(NOT _tip_storage_dep_match)
+  _tip_proof_fail("Expected Storage_Development CPack dependency declaration")
+endif()
+
+set(_tip_storage_dependencies "${CMAKE_MATCH_1}")
+foreach(_tip_expected_dependency IN ITEMS Storage Core Core_Development)
+  if(NOT "${_tip_expected_dependency}" IN_LIST _tip_storage_dependencies)
+    _tip_proof_fail("Expected Storage_Development to depend on '${_tip_expected_dependency}', got: ${_tip_storage_dependencies}")
+  endif()
+endforeach()
+
+message(STATUS "[proof] CPack component metadata proof passed.")

--- a/tests/cmake/proof_cpack_single_component_filter_test.cmake
+++ b/tests/cmake/proof_cpack_single_component_filter_test.cmake
@@ -1,0 +1,101 @@
+cmake_minimum_required(VERSION 3.25)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+if(NOT CMAKE_CPACK_COMMAND)
+  _tip_proof_fail("CMAKE_CPACK_COMMAND is required")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/cpack-single-component-filter")
+set(_tip_source_dir "${_tip_case_root}/fixture-src")
+set(_tip_build_dir "${_tip_case_root}/fixture-build")
+set(_tip_package_dir "${_tip_case_root}/packages")
+
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_source_dir}/src")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+
+file(
+  WRITE "${_tip_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 3.25)\n"
+  "project(proof_cpack_single_component_filter VERSION 1.0.0 LANGUAGES CXX)\n"
+  "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+  "add_library(single_filter SHARED src/single.cpp)\n"
+  "set_target_properties(single_filter PROPERTIES VERSION \${PROJECT_VERSION} SOVERSION \${PROJECT_VERSION_MAJOR})\n"
+  "if(WIN32)\n"
+  "  set_target_properties(single_filter PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)\n"
+  "endif()\n"
+  "target_install_package(single_filter EXPORT_NAME SingleFilterPkg)\n"
+  "export_cpack(PACKAGE_NAME SingleFilter PACKAGE_VERSION 1.0.0 GENERATORS TGZ COMPONENTS Development DEFAULT_COMPONENTS Development NO_DEFAULT_GENERATORS)\n")
+file(WRITE "${_tip_source_dir}/src/single.cpp" "int single_filter_value() { return 7; }\n")
+
+set(_tip_configure_command "${CMAKE_COMMAND}" -S "${_tip_source_dir}" -B "${_tip_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
+_tip_proof_run_step(NAME "fixture-configure" COMMAND ${_tip_configure_command})
+_tip_proof_run_step(
+  NAME
+  "fixture-build"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --build
+  "${_tip_build_dir}"
+  --config
+  Release)
+
+set(_tip_cpack_config_file "${_tip_build_dir}/CPackConfig.cmake")
+_tip_proof_assert_file_contains("${_tip_cpack_config_file}" "CPACK_COMPONENTS_ALL \"Development\"")
+_tip_proof_assert_file_contains("${_tip_cpack_config_file}" "CPACK_ARCHIVE_COMPONENT_INSTALL \"ON\"")
+_tip_proof_assert_file_contains("${_tip_cpack_config_file}" "CPACK_COMPONENT_DEVELOPMENT_DISABLED \"FALSE\"")
+_tip_proof_assert_file_not_contains("${_tip_cpack_config_file}" "CPACK_COMPONENTS_DEFAULT")
+_tip_proof_assert_file_not_contains("${_tip_cpack_config_file}" "CPACK_COMPONENT_DEVELOPMENT_DEPENDS \"Runtime\"")
+
+_tip_proof_run_step(
+  NAME
+  "fixture-cpack-tgz"
+  COMMAND
+  "${CMAKE_CPACK_COMMAND}"
+  -G
+  TGZ
+  --config
+  "${_tip_cpack_config_file}"
+  -B
+  "${_tip_package_dir}")
+
+file(GLOB _tip_archives "${_tip_package_dir}/*.tar.gz")
+list(LENGTH _tip_archives _tip_archive_count)
+if(NOT _tip_archive_count EQUAL 1)
+  _tip_proof_fail("Expected exactly one Development archive, got ${_tip_archive_count}: ${_tip_archives}")
+endif()
+list(GET _tip_archives 0 _tip_archive)
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" -E tar tf "${_tip_archive}"
+  RESULT_VARIABLE _tip_tar_result
+  OUTPUT_VARIABLE _tip_archive_contents
+  ERROR_VARIABLE _tip_tar_error)
+if(NOT _tip_tar_result EQUAL 0)
+  _tip_proof_fail("Failed to list Development archive: ${_tip_tar_error}")
+endif()
+
+foreach(_tip_expected_entry IN ITEMS "share/cmake/SingleFilterPkg" "SingleFilterPkgConfig.cmake" "single_filter")
+  string(FIND "${_tip_archive_contents}" "${_tip_expected_entry}" _tip_expected_entry_index)
+  if(_tip_expected_entry_index EQUAL -1)
+    _tip_proof_fail("Expected Development archive to contain '${_tip_expected_entry}'")
+  endif()
+endforeach()
+
+foreach(_tip_runtime_entry IN ITEMS "single_filter.so.1.0.0" "single_filter.so.1" "single_filter.1.0.0.dylib" "single_filter.1.dylib" "single_filter.dll")
+  string(FIND "${_tip_archive_contents}" "${_tip_runtime_entry}" _tip_runtime_entry_index)
+  if(NOT _tip_runtime_entry_index EQUAL -1)
+    _tip_proof_fail("Explicit Development-only package should not contain runtime entry '${_tip_runtime_entry}'")
+  endif()
+endforeach()
+
+message(STATUS "[proof] CPack single-component filter proof passed.")

--- a/tests/cmake/proof_cps_package_info_test.cmake
+++ b/tests/cmake/proof_cps_package_info_test.cmake
@@ -516,7 +516,7 @@ _tip_proof_run_step(
   --prefix
   "${_tip_repeat_target_install_prefix}"
   --component
-  Sdk_Development)
+  Development)
 set(_tip_repeat_target_cps_file "${_tip_repeat_target_install_prefix}/share/cps/repeatpkg/repeatpkg.cps")
 _tip_proof_assert_json_array("${_tip_repeat_target_cps_file}" "default_components" api)
 _tip_proof_assert_file_not_contains("${_tip_repeat_target_cps_file}" "\"core\"")
@@ -562,7 +562,7 @@ _tip_proof_run_step(
   --prefix
   "${_tip_repeat_override_install_prefix}"
   --component
-  Sdk_Development)
+  Development)
 set(_tip_repeat_override_cps_file "${_tip_repeat_override_install_prefix}/share/cps/repeatoverride/repeatoverride.cps")
 _tip_proof_assert_json_array("${_tip_repeat_override_cps_file}" "default_components" api)
 _tip_proof_assert_file_not_contains("${_tip_repeat_override_cps_file}" "\"repeat_override\"")

--- a/tests/cmake/proof_export_alias_conflict_test.cmake
+++ b/tests/cmake/proof_export_alias_conflict_test.cmake
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.25)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/export-alias-conflict")
+set(_tip_source_dir "${_tip_case_root}/fixture-src")
+set(_tip_build_dir "${_tip_case_root}/fixture-build")
+
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_source_dir}/src")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+
+file(
+  WRITE "${_tip_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 3.25)\n"
+  "project(proof_export_alias_conflict LANGUAGES CXX)\n"
+  "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+  "add_library(alias_a STATIC src/a.cpp)\n"
+  "add_library(alias_b STATIC src/b.cpp)\n"
+  "target_install_package(alias_a EXPORT_NAME AliasConflict NAMESPACE Alias:: ALIAS_NAME core)\n"
+  "target_install_package(alias_b EXPORT_NAME AliasConflict NAMESPACE Alias:: ALIAS_NAME core)\n")
+file(WRITE "${_tip_source_dir}/src/a.cpp" "int alias_a_value() { return 1; }\n")
+file(WRITE "${_tip_source_dir}/src/b.cpp" "int alias_b_value() { return 2; }\n")
+
+set(_tip_configure_command "${CMAKE_COMMAND}" -S "${_tip_source_dir}" -B "${_tip_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
+_tip_proof_expect_failure(
+  NAME
+  "alias-conflict-configure"
+  COMMAND
+  ${_tip_configure_command}
+  EXPECT_CONTAINS
+  "Duplicate exported target name"
+  "Use unique ALIAS_NAME values")
+
+message(STATUS "[proof] Export alias conflict proof passed.")

--- a/tests/cmake/proof_namelink_component_test.cmake
+++ b/tests/cmake/proof_namelink_component_test.cmake
@@ -1,0 +1,101 @@
+cmake_minimum_required(VERSION 3.25)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(WIN32)
+  message(STATUS "[proof] Skipping namelink component proof on Windows.")
+  return()
+endif()
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/namelink-component")
+set(_tip_fixture_source_dir "${_tip_case_root}/fixture-src")
+set(_tip_fixture_build_dir "${_tip_case_root}/fixture-build")
+set(_tip_runtime_install_prefix "${_tip_case_root}/runtime-install")
+set(_tip_development_install_prefix "${_tip_case_root}/development-install")
+
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_fixture_source_dir}/src")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+
+file(
+  WRITE "${_tip_fixture_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 3.25)\n"
+  "project(proof_namelink_component VERSION 1.2.3 LANGUAGES CXX)\n"
+  "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+  "add_library(proof_namelink SHARED src/proof.cpp)\n"
+  "set_target_properties(proof_namelink PROPERTIES VERSION \${PROJECT_VERSION} SOVERSION \${PROJECT_VERSION_MAJOR})\n"
+  "target_compile_features(proof_namelink PUBLIC cxx_std_17)\n"
+  "target_install_package(proof_namelink EXPORT_NAME proof_namelink_pkg COMPONENT Core)\n")
+
+file(WRITE "${_tip_fixture_source_dir}/src/proof.cpp" "int proof_namelink_value() { return 7; }\n")
+
+set(_tip_fixture_configure_command "${CMAKE_COMMAND}" -S "${_tip_fixture_source_dir}" -B "${_tip_fixture_build_dir}" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_INSTALL_LIBDIR=lib" ${_tip_toolchain_args})
+
+_tip_proof_run_step(NAME "fixture-configure" COMMAND ${_tip_fixture_configure_command})
+_tip_proof_run_step(
+  NAME
+  "fixture-build"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --build
+  "${_tip_fixture_build_dir}"
+  --config
+  Release)
+_tip_proof_run_step(
+  NAME
+  "fixture-install-runtime"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --install
+  "${_tip_fixture_build_dir}"
+  --config
+  Release
+  --prefix
+  "${_tip_runtime_install_prefix}"
+  --component
+  Core)
+
+if(APPLE)
+  set(_tip_runtime_library "${_tip_runtime_install_prefix}/lib/libproof_namelink.1.2.3.dylib")
+  set(_tip_runtime_soname_link "${_tip_runtime_install_prefix}/lib/libproof_namelink.1.dylib")
+  set(_tip_development_namelink "${_tip_runtime_install_prefix}/lib/libproof_namelink.dylib")
+  set(_tip_development_namelink_after_dev_install "${_tip_development_install_prefix}/lib/libproof_namelink.dylib")
+else()
+  set(_tip_runtime_library "${_tip_runtime_install_prefix}/lib/libproof_namelink.so.1.2.3")
+  set(_tip_runtime_soname_link "${_tip_runtime_install_prefix}/lib/libproof_namelink.so.1")
+  set(_tip_development_namelink "${_tip_runtime_install_prefix}/lib/libproof_namelink.so")
+  set(_tip_development_namelink_after_dev_install "${_tip_development_install_prefix}/lib/libproof_namelink.so")
+endif()
+
+_tip_proof_assert_exists("${_tip_runtime_library}")
+_tip_proof_assert_exists("${_tip_runtime_soname_link}")
+_tip_proof_assert_not_exists("${_tip_development_namelink}")
+
+_tip_proof_run_step(
+  NAME
+  "fixture-install-development"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --install
+  "${_tip_fixture_build_dir}"
+  --config
+  Release
+  --prefix
+  "${_tip_development_install_prefix}"
+  --component
+  Core_Development)
+
+if(NOT EXISTS "${_tip_development_namelink_after_dev_install}" AND NOT IS_SYMLINK "${_tip_development_namelink_after_dev_install}")
+  _tip_proof_fail("Expected development namelink to exist: ${_tip_development_namelink_after_dev_install}")
+endif()
+
+message(STATUS "[proof] Namelink component proof passed.")

--- a/tests/cmake/proof_namelink_component_test.cmake
+++ b/tests/cmake/proof_namelink_component_test.cmake
@@ -92,7 +92,7 @@ _tip_proof_run_step(
   --prefix
   "${_tip_development_install_prefix}"
   --component
-  Core_Development)
+  Development)
 
 if(NOT EXISTS "${_tip_development_namelink_after_dev_install}" AND NOT IS_SYMLINK "${_tip_development_namelink_after_dev_install}")
   _tip_proof_fail("Expected development namelink to exist: ${_tip_development_namelink_after_dev_install}")

--- a/tests/cmake/run_installed_consumer_test.cmake
+++ b/tests/cmake/run_installed_consumer_test.cmake
@@ -31,13 +31,9 @@ set(_tip_main_install_command "${CMAKE_COMMAND}" --install "${TIP_MAIN_BUILD_DIR
 if(DEFINED TIP_MAIN_INSTALL_CONFIG AND NOT TIP_MAIN_INSTALL_CONFIG STREQUAL "")
   list(APPEND _tip_main_install_command --config "${TIP_MAIN_INSTALL_CONFIG}")
 endif()
-list(APPEND _tip_main_install_command --prefix "${_tip_install_prefix}" --component CMakeUtilities_Development)
+list(APPEND _tip_main_install_command --prefix "${_tip_install_prefix}" --component Development)
 
-_tip_proof_run_step(
-  NAME
-  "install-target-install-package"
-  COMMAND
-  ${_tip_main_install_command})
+_tip_proof_run_step(NAME "install-target-install-package" COMMAND ${_tip_main_install_command})
 
 set(_tip_installed_helper_dir "${_tip_install_prefix}/share/cmake/target_install_package")
 foreach(_tip_installed_helper IN ITEMS generic-config.cmake.in sign_packages.cmake.in external_container_package.cmake collect_runtime_deps.sh build_minimal_container.sh container_to_quadlet.sh)
@@ -62,12 +58,30 @@ if(UNIX)
   endforeach()
 endif()
 
-set(_tip_consumer_configure_command "${CMAKE_COMMAND}" -S "${TIP_REPO_ROOT}/tests/consumer" -B "${_tip_consumer_build_dir}" "-DCMAKE_BUILD_TYPE=Release"
-                                    "-DCMAKE_PREFIX_PATH=${_tip_install_prefix}" "-DTIP_CONSUMER_ENABLE_CHECKSUMS=ON" ${_tip_toolchain_args})
+set(_tip_consumer_configure_command "${CMAKE_COMMAND}" -S "${TIP_REPO_ROOT}/tests/consumer" -B "${_tip_consumer_build_dir}" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_PREFIX_PATH=${_tip_install_prefix}"
+                                    "-DTIP_CONSUMER_ENABLE_CHECKSUMS=ON" ${_tip_toolchain_args})
 
 _tip_proof_run_step(NAME "consumer-configure" COMMAND ${_tip_consumer_configure_command})
-_tip_proof_run_step(NAME "consumer-build" COMMAND "${CMAKE_COMMAND}" --build "${_tip_consumer_build_dir}" --config Release)
-_tip_proof_run_step(NAME "consumer-install" COMMAND "${CMAKE_COMMAND}" --install "${_tip_consumer_build_dir}" --config Release --prefix "${_tip_consumer_install_prefix}")
+_tip_proof_run_step(
+  NAME
+  "consumer-build"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --build
+  "${_tip_consumer_build_dir}"
+  --config
+  Release)
+_tip_proof_run_step(
+  NAME
+  "consumer-install"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --install
+  "${_tip_consumer_build_dir}"
+  --config
+  Release
+  --prefix
+  "${_tip_consumer_install_prefix}")
 
 if(WIN32)
   set(_tip_consumer_executable "${_tip_consumer_install_prefix}/bin/consumer.exe")
@@ -142,8 +156,7 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
   file(MAKE_DIRECTORY "${_tip_fake_bin_dir}")
 
   file(
-    WRITE
-    "${_tip_fake_bin_dir}/podman"
+    WRITE "${_tip_fake_bin_dir}/podman"
     "#!/bin/sh\n"
     "printf '%s\\n' \"$@\" >> \"${TIP_CONSUMER_TEST_ROOT}/podman.log\"\n"
     "case \"$1\" in\n"
@@ -174,19 +187,19 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
     WORLD_READ
     WORLD_EXECUTE)
 
-  set(_tip_container_consumer_configure_command
-      "${CMAKE_COMMAND}"
-      -S
-      "${TIP_REPO_ROOT}/tests/consumer"
-      -B
-      "${_tip_container_consumer_build_dir}"
-      "-DCMAKE_BUILD_TYPE=Release"
-      "-DCMAKE_PREFIX_PATH=${_tip_install_prefix}"
-      "-DTIP_CONSUMER_ENABLE_CONTAINER=ON"
-      ${_tip_toolchain_args})
+  set(_tip_container_consumer_configure_command "${CMAKE_COMMAND}" -S "${TIP_REPO_ROOT}/tests/consumer" -B "${_tip_container_consumer_build_dir}" "-DCMAKE_BUILD_TYPE=Release"
+                                                "-DCMAKE_PREFIX_PATH=${_tip_install_prefix}" "-DTIP_CONSUMER_ENABLE_CONTAINER=ON" ${_tip_toolchain_args})
 
   _tip_proof_run_step(NAME "container-consumer-configure" COMMAND ${_tip_container_consumer_configure_command})
-  _tip_proof_run_step(NAME "container-consumer-build" COMMAND "${CMAKE_COMMAND}" --build "${_tip_container_consumer_build_dir}" --config Release)
+  _tip_proof_run_step(
+    NAME
+    "container-consumer-build"
+    COMMAND
+    "${CMAKE_COMMAND}"
+    --build
+    "${_tip_container_consumer_build_dir}"
+    --config
+    Release)
   _tip_proof_run_step(
     NAME
     "container-consumer-package"

--- a/tests/cmake/run_layout_matrix_test.cmake
+++ b/tests/cmake/run_layout_matrix_test.cmake
@@ -250,7 +250,7 @@ _tip_run_step(
   --prefix
   "${_development_prefix}"
   --component
-  "Layout_Development")
+  "Development")
 _tip_run_step(
   NAME
   "install-full"
@@ -342,9 +342,7 @@ _tip_assert_any_file_contains("${_import_prefix_literal}/${_layout_prefix}${_ins
 set(_current_list_dir_literal "\${CMAKE_CURRENT_LIST_DIR}")
 _tip_assert_file_contains("${_development_cmake_dir}/layout_matrixConfig.cmake" "include(\"${_current_list_dir_literal}/layout_matrixTargets.cmake\")")
 
-set(_installed_runner_candidates
-    "${_full_bindir}/layout_runner${_tip_executable_suffix}"
-    "${_full_bindir}/layout_runner")
+set(_installed_runner_candidates "${_full_bindir}/layout_runner${_tip_executable_suffix}" "${_full_bindir}/layout_runner")
 _tip_find_existing_path(_installed_runner ${_installed_runner_candidates})
 _tip_run_step(NAME "run-installed-layout-runner" COMMAND "${_installed_runner}")
 
@@ -353,8 +351,7 @@ set(_consumer_build_dir "${_consumer_dir}/b")
 file(MAKE_DIRECTORY "${_consumer_dir}")
 
 file(
-  WRITE
-  "${_consumer_dir}/CMakeLists.txt"
+  WRITE "${_consumer_dir}/CMakeLists.txt"
   [=[
 cmake_minimum_required(VERSION 3.25)
 project(layout_matrix_consumer LANGUAGES CXX)
@@ -381,8 +378,7 @@ target_link_libraries(layout_matrix_consumer PRIVATE layout_matrix::layout_archi
 ]=])
 
 file(
-  WRITE
-  "${_consumer_dir}/main.cpp"
+  WRITE "${_consumer_dir}/main.cpp"
   [=[
 #include "layout/layout.hpp"
 
@@ -393,14 +389,7 @@ int main() {
 }
 ]=])
 
-set(_consumer_configure_command
-    "${CMAKE_COMMAND}"
-    -S
-    "${_consumer_dir}"
-    -B
-    "${_consumer_build_dir}"
-    "-DCMAKE_PREFIX_PATH=${_full_prefix}"
-    "-DCMAKE_BUILD_TYPE=${TIP_LAYOUT_CONSUMER_CONFIG}")
+set(_consumer_configure_command "${CMAKE_COMMAND}" -S "${_consumer_dir}" -B "${_consumer_build_dir}" "-DCMAKE_PREFIX_PATH=${_full_prefix}" "-DCMAKE_BUILD_TYPE=${TIP_LAYOUT_CONSUMER_CONFIG}")
 if(DEFINED TIP_CMAKE_GENERATOR AND NOT TIP_CMAKE_GENERATOR STREQUAL "")
   list(APPEND _consumer_configure_command -G "${TIP_CMAKE_GENERATOR}")
   if(TIP_CMAKE_GENERATOR MATCHES "Multi-Config|Visual Studio|Xcode")
@@ -438,10 +427,8 @@ _tip_run_step(
   "${TIP_LAYOUT_CONSUMER_CONFIG}")
 
 set(_consumer_executable_candidates
-    "${_consumer_build_dir}/layout_matrix_consumer${_tip_executable_suffix}"
-    "${_consumer_build_dir}/${TIP_LAYOUT_CONSUMER_CONFIG}/layout_matrix_consumer${_tip_executable_suffix}"
-    "${_consumer_build_dir}/layout_matrix_consumer"
-    "${_consumer_build_dir}/${TIP_LAYOUT_CONSUMER_CONFIG}/layout_matrix_consumer")
+    "${_consumer_build_dir}/layout_matrix_consumer${_tip_executable_suffix}" "${_consumer_build_dir}/${TIP_LAYOUT_CONSUMER_CONFIG}/layout_matrix_consumer${_tip_executable_suffix}"
+    "${_consumer_build_dir}/layout_matrix_consumer" "${_consumer_build_dir}/${TIP_LAYOUT_CONSUMER_CONFIG}/layout_matrix_consumer")
 _tip_find_existing_path(_consumer_executable ${_consumer_executable_candidates})
 
 if(WIN32)

--- a/tests/cpack-regression/test-single-component.sh
+++ b/tests/cpack-regression/test-single-component.sh
@@ -54,7 +54,7 @@ cmake --build "${BUILD_DIR}"
 echo "Generating packages..."
 (cd "${BUILD_DIR}" && cpack --verbose)
 
-# Verify that only TGZ packages are generated (no DEB/RPM due to single component)
+# Verify that only TGZ packages are generated because the fixture requested only TGZ.
 echo "Verifying generated packages..."
 if (cd "${BUILD_DIR}" && ls SimpleLib-*.tar.gz 1> /dev/null 2>&1); then
   echo "✅ Single component package generated"


### PR DESCRIPTION
## Summary

- Finalize registered target-install exports before deferred `export_cpack()` reads auto-detected components.
- Install generated CMake package metadata with every development component, add CPack dependencies so development packages for a shared export pull the complete target set, and route shared-library namelinks to development components.
- Make `COMPONENT_DEPENDENCIES` respect optional `find_package(... OPTIONAL_COMPONENTS ...)` requests without failing the whole package.
- Update docs and examples for v7.0.1 helper loading, metadata placement, namelink routing, and optional component dependency behavior.

## Root Cause

The v7 component model split runtime and development payloads, but some generated package metadata still assumed one development owner or required dependency behavior. Deferred CPack setup could also run before target exports had finalized when users called `export_cpack()` early.

## Validation

- `cmake -S . -B build/fix-v7-followups -DTARGET_INSTALL_PACKAGE_ENABLE_INSTALL=ON -Dtarget_install_package_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build/fix-v7-followups --config Release`
- `ctest --test-dir build/fix-v7-followups --output-on-failure`
- `cmake -S . -B build/fix-v7-followups-multi -G "Ninja Multi-Config" -DTARGET_INSTALL_PACKAGE_ENABLE_INSTALL=ON -Dtarget_install_package_BUILD_TESTS=ON`
- `cmake --build build/fix-v7-followups-multi --config Debug`
- `ctest --test-dir build/fix-v7-followups-multi -C Debug --output-on-failure`
- `cmake --install build/fix-v7-followups --config Release --prefix build/fix-v7-followups/install`
- `cpack --config build/fix-v7-followups/tests/proofs/cpack-component-metadata/fixture-build/CPackConfig.cmake -G RPM -B build/fix-v7-followups/tests/proofs/cpack-component-metadata/rpm-packages`
- `git diff --check`