### PR TITLE
Dogfood signed release packaging

### DIFF
--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -92,6 +92,37 @@ jobs:
           set -euxo pipefail
           bash ci/run.sh cpack --suite components
 
+  cpack-self-release:
+    name: Self Release Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bootstrap (ninja + gpg)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          bash ci/run.sh bootstrap --ninja --gpg
+
+      - name: Build signed self-release package
+        shell: bash
+        run: |
+          set -euxo pipefail
+          bash ci/run.sh cpack --suite self-release
+
+      - name: Upload self-release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: target-install-package-self-release
+          path: |
+            build/cpack/self-release/packages/*.tar.gz
+            build/cpack/self-release/packages/*.zip
+            build/cpack/self-release/packages/*.sig
+            build/cpack/self-release/packages/*.sha256
+            build/cpack/self-release/packages/*.sha512
+            build/cpack/self-release/packages/*.asc
+          retention-days: 7
+
   cpack-cross-platform:
     name: CPack Cross-Platform Package and Signature Validation
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,153 @@
+name: Tagged Release
+
+on:
+  push:
+    tags: [ "v*" ]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build Signed Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check tag matches project version
+        shell: bash
+        run: |
+          set -euo pipefail
+          project_version="$(
+            python3 - <<'PY'
+          import pathlib
+          import re
+
+          text = pathlib.Path("CMakeLists.txt").read_text(encoding="utf-8")
+          match = re.search(r"project\s*\(\s*target_install_package\b(?P<body>.*?)\)", text, re.S)
+          if not match:
+              raise SystemExit(1)
+          version = re.search(r"\bVERSION\s+([^\s\)]+)", match.group("body"))
+          if not version:
+              raise SystemExit(1)
+          print(version.group(1))
+          PY
+          )"
+          if [[ -z "${project_version}" ]]; then
+            echo "Could not read project version from CMakeLists.txt" >&2
+            exit 1
+          fi
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [[ "${tag_version}" != "${project_version}" ]]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match project version ${project_version}" >&2
+            exit 1
+          fi
+
+      - name: Bootstrap (ninja + gpg)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          bash ci/run.sh bootstrap --ninja --gpg
+
+      - name: Import release signing key
+        shell: bash
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_SIGNING_KEY_SECRET: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GPG_PRIVATE_KEY}" ]]; then
+            echo "GPG_PRIVATE_KEY secret is required for tagged releases" >&2
+            exit 1
+          fi
+
+          mkdir -p "${HOME}/.gnupg"
+          chmod 700 "${HOME}/.gnupg"
+          printf '%s\n' "allow-loopback-pinentry" >> "${HOME}/.gnupg/gpg-agent.conf"
+          gpgconf --kill gpg-agent || true
+
+          printf '%s\n' "${GPG_PRIVATE_KEY}" | gpg --batch --import
+
+          if [[ -n "${GPG_SIGNING_KEY_SECRET}" ]]; then
+            signing_key="${GPG_SIGNING_KEY_SECRET}"
+          else
+            signing_key="$(gpg --batch --list-secret-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }')"
+          fi
+          if [[ -z "${signing_key}" ]]; then
+            echo "Could not determine imported GPG signing key fingerprint" >&2
+            exit 1
+          fi
+          gpg --batch --list-secret-keys "${signing_key}" >/dev/null
+          printf 'GPG_SIGNING_KEY=%s\n' "${signing_key}" >> "${GITHUB_ENV}"
+
+          if [[ -n "${GPG_PASSPHRASE}" ]]; then
+            passphrase_file="${RUNNER_TEMP}/target-install-package-gpg-passphrase"
+            umask 077
+            printf '%s' "${GPG_PASSPHRASE}" > "${passphrase_file}"
+            printf 'GPG_PASSPHRASE_FILE=%s\n' "${passphrase_file}" >> "${GITHUB_ENV}"
+          fi
+
+      - name: Build signed release artifacts
+        shell: bash
+        run: |
+          set -euxo pipefail
+          bash ci/run.sh cpack --suite self-release --require-signing --package-dir build/release-packages
+
+      - name: Write release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "Signed target_install_package ${GITHUB_REF_NAME} release artifacts."
+            echo
+            echo "Assets include TGZ and ZIP install-tree archives, detached GPG signatures, SHA256/SHA512 checksums, and the exported public signing key."
+            echo
+            echo "Verify an archive with:"
+            echo
+            echo '```sh'
+            echo "gpg --import target_install_package-signing-key.asc"
+            echo "gpg --verify target_install_package-${GITHUB_REF_NAME#v}-cmake.tar.gz.sig target_install_package-${GITHUB_REF_NAME#v}-cmake.tar.gz"
+            echo "sha256sum -c target_install_package-${GITHUB_REF_NAME#v}-cmake.tar.gz.sha256"
+            echo '```'
+          } > build/release-notes.md
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: target-install-package-${{ github.ref_name }}
+          path: |
+            build/release-packages/*.tar.gz
+            build/release-packages/*.zip
+            build/release-packages/*.sig
+            build/release-packages/*.sha256
+            build/release-packages/*.sha512
+            build/release-packages/*.asc
+            build/release-notes.md
+          retention-days: 30
+
+      - name: Publish GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mapfile -t release_assets < <(
+            find build/release-packages -maxdepth 1 -type f \
+              \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.sig' -o -name '*.sha256' -o -name '*.sha512' -o -name '*.asc' \) \
+              | sort
+          )
+          if (( ${#release_assets[@]} == 0 )); then
+            echo "No release assets found" >&2
+            exit 1
+          fi
+
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" "${release_assets[@]}" --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" \
+              --verify-tag \
+              --title "${GITHUB_REF_NAME}" \
+              --notes-file build/release-notes.md \
+              "${release_assets[@]}"
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(target_install_package VERSION 7.0.3)
+project(
+  target_install_package
+  VERSION 7.0.3
+  DESCRIPTION "CMake utilities for creating installable packages"
+  HOMEPAGE_URL "https://github.com/jkammerland/target_install_package.cmake")
 
 # ~~~
 # Project dependencies, these have been included directly in this project for
@@ -24,6 +28,14 @@ add_library(${PROJECT_NAME} INTERFACE)
 # Only install if this is the main project or if explicitly enabled
 option(TARGET_INSTALL_PACKAGE_ENABLE_INSTALL "Create install configuration for ${PROJECT_NAME}" OFF)
 option(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL "FOR CI: Do not create install configuration for ${PROJECT_NAME}" OFF)
+option(TARGET_INSTALL_PACKAGE_ENABLE_CPACK "Configure CPack release archives for ${PROJECT_NAME}" OFF)
+option(TARGET_INSTALL_PACKAGE_REQUIRE_SIGNING "Require GPG signing for ${PROJECT_NAME} CPack archives" OFF)
+set(GPG_SIGNING_KEY
+    ""
+    CACHE STRING "GPG key fingerprint or key id used to sign CPack archives")
+set(GPG_PASSPHRASE_FILE
+    ""
+    CACHE FILEPATH "File containing the GPG key passphrase for noninteractive CPack signing")
 if(NOT TARGET_INSTALL_PACKAGE_DISABLE_INSTALL)
   if(PROJECT_IS_TOP_LEVEL OR TARGET_INSTALL_PACKAGE_ENABLE_INSTALL)
     # Use target_install_package to install itself and target_configure_sources
@@ -56,7 +68,57 @@ if(NOT TARGET_INSTALL_PACKAGE_DISABLE_INSTALL)
       PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/cmake/build_minimal_container.sh ${CMAKE_CURRENT_LIST_DIR}/cmake/collect_runtime_deps.sh ${CMAKE_CURRENT_LIST_DIR}/cmake/container_to_quadlet.sh
       DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
       COMPONENT Development)
+    install(
+      FILES ${CMAKE_CURRENT_LIST_DIR}/LICENSE
+      DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/${PROJECT_NAME}
+      COMPONENT Development)
   endif()
+endif()
+
+if(TARGET_INSTALL_PACKAGE_ENABLE_CPACK)
+  if(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL)
+    message(FATAL_ERROR "TARGET_INSTALL_PACKAGE_ENABLE_CPACK requires install rules; disable TARGET_INSTALL_PACKAGE_DISABLE_INSTALL.")
+  endif()
+
+  set(_tip_self_cpack_signing_args GENERATE_CHECKSUMS ON)
+  if(TARGET_INSTALL_PACKAGE_REQUIRE_SIGNING
+     OR GPG_SIGNING_KEY
+     OR (DEFINED ENV{GPG_SIGNING_KEY} AND NOT "$ENV{GPG_SIGNING_KEY}" STREQUAL ""))
+    list(APPEND _tip_self_cpack_signing_args SIGNING_METHOD detached)
+    if(GPG_SIGNING_KEY)
+      list(APPEND _tip_self_cpack_signing_args GPG_SIGNING_KEY "${GPG_SIGNING_KEY}")
+    endif()
+    if(GPG_PASSPHRASE_FILE)
+      list(APPEND _tip_self_cpack_signing_args GPG_PASSPHRASE_FILE "${GPG_PASSPHRASE_FILE}")
+    endif()
+  endif()
+
+  export_cpack(
+    PACKAGE_NAME
+    "${PROJECT_NAME}"
+    PACKAGE_VERSION
+    "${PROJECT_VERSION}"
+    PACKAGE_VENDOR
+    "jkammerland"
+    PACKAGE_CONTACT
+    "https://github.com/jkammerland/target_install_package.cmake/issues"
+    PACKAGE_DESCRIPTION
+    "${PROJECT_DESCRIPTION}"
+    PACKAGE_HOMEPAGE_URL
+    "${PROJECT_HOMEPAGE_URL}"
+    PACKAGE_LICENSE
+    "MIT"
+    LICENSE_FILE
+    "${CMAKE_CURRENT_LIST_DIR}/LICENSE"
+    GENERATORS
+    TGZ
+    ZIP
+    ${_tip_self_cpack_signing_args}
+    ADDITIONAL_CPACK_VARS
+    CPACK_PACKAGE_FILE_NAME
+    "${PROJECT_NAME}-${PROJECT_VERSION}-cmake"
+    CPACK_SYSTEM_NAME
+    "cmake")
 endif()
 
 option(${PROJECT_NAME}_BUILD_TESTS "Run the tests" OFF)

--- a/ci/cmd/cpack.sh
+++ b/ci/cmd/cpack.sh
@@ -15,6 +15,7 @@ Usage: ci/run.sh cpack [options]
 
 Suites:
   basic          CPack basic example + signing setup (safe for per-job CI matrix execution)
+  self-release   CPack the root project install tree and verify signed release archives
   components     CPack components example integration (Linux)
   cross-platform Cross-platform artifact analysis (Linux, after download-artifact)
   regression     Run tests/cpack-regression/run-all-tests.sh (Linux)
@@ -25,6 +26,8 @@ Options:
   --cc <path>            C compiler for configure
   --cxx <path>           C++ compiler for configure
   --artifacts-dir <dir>  For cross-platform suite (default: ./build/cpack/artifacts)
+  --package-dir <dir>    For self-release suite (default: ./build/cpack/self-release/packages)
+  --require-signing      Fail if GPG_SIGNING_KEY is not provided instead of creating a test key
   -h, --help             Show help
 EOF
 }
@@ -34,6 +37,8 @@ build_type="Release"
 cc=""
 cxx=""
 artifacts_dir="${ci_root}/build/cpack/artifacts"
+package_dir="${ci_root}/build/cpack/self-release/packages"
+require_signing=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -60,6 +65,14 @@ while [[ $# -gt 0 ]]; do
     --artifacts-dir)
       artifacts_dir="$(ci_abs_path "${2:?}")"
       shift 2
+      ;;
+    --package-dir)
+      package_dir="$(ci_abs_path "${2:?}")"
+      shift 2
+      ;;
+    --require-signing)
+      require_signing=true
+      shift
       ;;
     *)
       usage >&2
@@ -399,6 +412,130 @@ run_basic() {
   fi
 }
 
+run_self_release() {
+  ci_require_cmd cpack
+  ci_require_cmd gpg
+
+  if [[ "${require_signing}" == "true" && -z "${GPG_SIGNING_KEY:-}" ]]; then
+    ci_die "--require-signing requires GPG_SIGNING_KEY to name an imported private key"
+  fi
+
+  if [[ -z "${GPG_SIGNING_KEY:-}" ]]; then
+    ci_log "==> Generate test GPG key for self-release package signing"
+    mkdir -p "${ci_root}/build/ci-deps"
+    generate_test_gpg_key
+  fi
+
+  local work_dir="${ci_root}/build/cpack/self-release"
+  local build_dir="${work_dir}/build"
+  local install_dir="${work_dir}/install"
+  local extract_dir="${work_dir}/extract"
+  local consumer_dir="${work_dir}/consumer"
+  local consumer_build_dir="${work_dir}/consumer-build"
+
+  rm -rf "${build_dir}" "${install_dir}" "${extract_dir}" "${consumer_dir}" "${consumer_build_dir}" "${package_dir}"
+  mkdir -p "${build_dir}" "${package_dir}"
+
+  ci_log "==> Configure root self-release package"
+  cmake --log-level=DEBUG -S "${ci_root}" -B "${build_dir}" -G Ninja \
+    ${cc:+-DCMAKE_C_COMPILER=${cc}} \
+    ${cxx:+-DCMAKE_CXX_COMPILER=${cxx}} \
+    -DCMAKE_BUILD_TYPE="${build_type}" \
+    -DCMAKE_INSTALL_PREFIX=/ \
+    -DCMAKE_INSTALL_DATADIR=share \
+    -DCPACK_PACKAGE_DIRECTORY="$(ci_path_for_cmake "${package_dir}")" \
+    -DPROJECT_LOG_COLORS=ON \
+    -DTARGET_INSTALL_PACKAGE_ENABLE_INSTALL=ON \
+    -DTARGET_INSTALL_PACKAGE_ENABLE_CPACK=ON \
+    -DTARGET_INSTALL_PACKAGE_REQUIRE_SIGNING=ON
+
+  ci_log "==> Build root self-release package"
+  cmake --build "${build_dir}" --config "${build_type}"
+
+  ci_log "==> Install root project for inspection"
+  cmake --install "${build_dir}" --config "${build_type}" --prefix "${install_dir}"
+
+  ci_log "==> Generate root release archives"
+  cpack --config "${build_dir}/CPackConfig.cmake" --verbose
+
+  shopt -s nullglob
+  local packages=("${package_dir}"/target_install_package-*-cmake.tar.gz "${package_dir}"/target_install_package-*-cmake.zip)
+  local tgz_packages=("${package_dir}"/target_install_package-*-cmake.tar.gz)
+  shopt -u nullglob
+
+  if (( ${#packages[@]} != 2 )); then
+    printf '%s\n' "${packages[@]}" >&2
+    ci_die "Expected exactly two self-release archives (TGZ and ZIP), found ${#packages[@]}"
+  fi
+  if (( ${#tgz_packages[@]} != 1 )); then
+    ci_die "Expected exactly one TGZ self-release archive, found ${#tgz_packages[@]}"
+  fi
+
+  ci_log "==> Verify root release signatures and checksums"
+  local package_file package_name
+  for package_file in "${packages[@]}"; do
+    package_name="$(basename "${package_file}")"
+    [[ -f "${package_file}.sig" ]] || ci_die "Missing detached signature for ${package_name}"
+    [[ -f "${package_file}.sha256" ]] || ci_die "Missing SHA256 checksum for ${package_name}"
+    [[ -f "${package_file}.sha512" ]] || ci_die "Missing SHA512 checksum for ${package_name}"
+    gpg --verify "${package_file}.sig" "${package_file}" >/dev/null
+    (cd "${package_dir}" && sha256sum -c "${package_name}.sha256")
+    (cd "${package_dir}" && sha512sum -c "${package_name}.sha512")
+  done
+
+  if gpg --armor --export "${GPG_SIGNING_KEY}" >"${package_dir}/target_install_package-signing-key.asc"; then
+    ci_log "✓ Exported public signing key"
+  else
+    ci_warn "Unable to export public signing key for ${GPG_SIGNING_KEY}"
+    rm -f "${package_dir}/target_install_package-signing-key.asc"
+  fi
+
+  ci_log "==> Verify packaged install tree with find_package()"
+  mkdir -p "${extract_dir}" "${consumer_dir}"
+  (cd "${extract_dir}" && cmake -E tar xzf "${tgz_packages[0]}")
+  local archive_root="${extract_dir}"
+  shopt -s nullglob
+  local archive_roots=("${extract_dir}"/target_install_package-*-cmake)
+  shopt -u nullglob
+  if (( ${#archive_roots[@]} == 1 )) && [[ -d "${archive_roots[0]}" ]]; then
+    archive_root="${archive_roots[0]}"
+  fi
+
+  local extracted_prefix="${archive_root}"
+  if [[ -f "${archive_root}/share/cmake/target_install_package/target_install_packageConfig.cmake" ]]; then
+    extracted_prefix="${archive_root}"
+  elif [[ -f "${archive_root}/usr/share/cmake/target_install_package/target_install_packageConfig.cmake" ]]; then
+    extracted_prefix="${archive_root}/usr"
+  else
+    ci_die "Extracted archive is missing target_install_packageConfig.cmake"
+  fi
+  [[ -f "${extracted_prefix}/share/cmake/target_install_package/sign_packages.cmake.in" ]] \
+    || ci_die "Extracted archive is missing sign_packages.cmake.in"
+  [[ -f "${extracted_prefix}/share/doc/target_install_package/LICENSE" ]] || ci_die "Extracted archive is missing LICENSE"
+
+  cat >"${consumer_dir}/CMakeLists.txt" <<'EOF'
+cmake_minimum_required(VERSION 3.25)
+project(target_install_package_self_release_consumer LANGUAGES CXX)
+
+find_package(target_install_package CONFIG REQUIRED)
+
+foreach(_tip_required_command IN ITEMS target_install_package target_configure_sources export_cpack)
+  if(NOT COMMAND ${_tip_required_command})
+    message(FATAL_ERROR "Expected command not loaded by target_install_package: ${_tip_required_command}")
+  endif()
+endforeach()
+
+if(NOT TARGET target_install_package::target_install_package)
+  message(FATAL_ERROR "Expected imported target target_install_package::target_install_package")
+endif()
+EOF
+
+  cmake -S "${consumer_dir}" -B "${consumer_build_dir}" -DCMAKE_PREFIX_PATH="$(ci_path_for_cmake "${extracted_prefix}")"
+
+  ci_log "==> Self-release package artifacts"
+  (cd "${package_dir}" && ls -la)
+}
+
 run_components() {
   if ! ci_is_linux; then
     ci_die "components suite is Linux-only"
@@ -486,6 +623,7 @@ run_regression() {
 
 case "${suite}" in
   basic) run_basic ;;
+  self-release) run_self_release ;;
   components) run_components ;;
   cross-platform) run_cross_platform ;;
   regression) run_regression ;;

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -20,6 +20,10 @@ graph TD
   CPK --> CPK2[cpack regression]
   CPK --> CPK3[cpack components]
   CPK --> CPK4[cross-platform validation]
+  CPK --> CPK5[self-release package]
+
+  REL[.github/workflows/release.yml] --> REL1[signed self-release package]
+  REL --> REL2[GitHub release upload]
 ```
 
 ## Workflow → script mapping
@@ -31,6 +35,7 @@ graph TD
   - `*-consume`: `ci/run.sh examples --suite consume-*`
 - `packaging-tests.yml`: `ci/run.sh bootstrap --packaging-tools` → `ci/run.sh packaging-tests`
 - `cpack.yml`: `ci/run.sh bootstrap --packaging-tools --gpg` → `ci/run.sh cpack ...`
+- `release.yml`: imports the release GPG key, runs `ci/run.sh cpack --suite self-release --require-signing`, then uploads the signed artifacts to the tag's GitHub release
 
 ## Local parity (common entrypoints)
 
@@ -40,6 +45,7 @@ graph TD
 - Examples: `bash ci/run.sh examples --suite single --build-type Release --use-fetchcontent`
 - Packaging: `bash ci/run.sh packaging-tests`
 - CPack: `bash ci/run.sh cpack --suite regression`
+- Self-release package dry run: `bash ci/run.sh bootstrap --ninja --gpg && bash ci/run.sh cpack --suite self-release`
 
 ## Logging and outputs
 


### PR DESCRIPTION
## Summary
- Add an opt-in self-release CPack export for this project so it packages its own installed CMake module tree.
- Add a self-release CI job and tag-driven GitHub release workflow that produce signed TGZ/ZIP archives, checksums, and a public signing key artifact.
- Document the release-package workflow and required GPG secrets.

## Validation
- `cmake-format -c .cmake-format.py CMakeLists.txt --check`
- `bash -n ci/cmd/cpack.sh`
- YAML parse for `.github/workflows/cpack.yml` and `.github/workflows/release.yml`
- `bash ci/run.sh cpack --suite self-release`