### PR TITLE
Dogfood SPDX SBOM releases

### DIFF
--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          bash ci/run.sh bootstrap --ninja --gpg
+          bash ci/run.sh bootstrap --cmake-version 4.3.1 --ninja --gpg
 
       - name: Build signed self-release package
         shell: bash
@@ -121,6 +121,7 @@ jobs:
             build/cpack/self-release/packages/*.sha256
             build/cpack/self-release/packages/*.sha512
             build/cpack/self-release/packages/*.asc
+            build/cpack/self-release/packages/*.spdx.json
           retention-days: 7
 
   cpack-cross-platform:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          bash ci/run.sh bootstrap --ninja --gpg
+          bash ci/run.sh bootstrap --cmake-version 4.3.1 --ninja --gpg
 
       - name: Import release signing key
         shell: bash
@@ -101,13 +101,14 @@ jobs:
           {
             echo "Signed target_install_package ${GITHUB_REF_NAME} release artifacts."
             echo
-            echo "Assets include TGZ and ZIP install-tree archives, detached GPG signatures, SHA256/SHA512 checksums, and the exported public key for verifying release signatures."
+            echo "Assets include TGZ and ZIP install-tree archives, an SPDX SBOM, detached GPG signatures, SHA256/SHA512 checksums, and the exported public key for verifying release signatures."
             echo
             echo "Verify an archive with:"
             echo
             echo '```sh'
             echo "gpg --import target_install_package-release-public-key.asc"
             echo "gpg --verify target_install_package-${GITHUB_REF_NAME#v}-cmake.tar.gz.sig target_install_package-${GITHUB_REF_NAME#v}-cmake.tar.gz"
+            echo "gpg --verify target_install_package-${GITHUB_REF_NAME#v}-cmake.spdx.json.sig target_install_package-${GITHUB_REF_NAME#v}-cmake.spdx.json"
             echo "sha256sum -c target_install_package-${GITHUB_REF_NAME#v}-cmake.tar.gz.sha256"
             echo '```'
           } > build/release-notes.md
@@ -123,6 +124,7 @@ jobs:
             build/release-packages/*.sha256
             build/release-packages/*.sha512
             build/release-packages/*.asc
+            build/release-packages/*.spdx.json
             build/release-notes.md
           retention-days: 30
 
@@ -134,7 +136,7 @@ jobs:
           set -euo pipefail
           mapfile -t release_assets < <(
             find build/release-packages -maxdepth 1 -type f \
-              \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.sig' -o -name '*.sha256' -o -name '*.sha512' -o -name '*.asc' \) \
+              \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.spdx.json' -o -name '*.sig' -o -name '*.sha256' -o -name '*.sha512' -o -name '*.asc' \) \
               | sort
           )
           if (( ${#release_assets[@]} == 0 )); then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(
   VERSION 7.0.4
   DESCRIPTION "CMake utilities for creating installable packages"
   HOMEPAGE_URL "https://github.com/jkammerland/target_install_package.cmake")
+set(target_install_package_SPDX_LICENSE "MIT")
 
 # ~~~
 # Project dependencies, these have been included directly in this project for
@@ -24,11 +25,13 @@ include(${CMAKE_CURRENT_LIST_DIR}/export_cpack.cmake)
 
 # Create an INTERFACE library to represent our modules
 add_library(${PROJECT_NAME} INTERFACE)
+set_target_properties(${PROJECT_NAME} PROPERTIES SPDX_LICENSE "${target_install_package_SPDX_LICENSE}")
 
 # Only install if this is the main project or if explicitly enabled
 option(TARGET_INSTALL_PACKAGE_ENABLE_INSTALL "Create install configuration for ${PROJECT_NAME}" OFF)
 option(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL "FOR CI: Do not create install configuration for ${PROJECT_NAME}" OFF)
 option(TARGET_INSTALL_PACKAGE_ENABLE_CPACK "Configure CPack release archives for ${PROJECT_NAME}" OFF)
+option(TARGET_INSTALL_PACKAGE_ENABLE_SBOM "Install SPDX SBOM metadata for ${PROJECT_NAME}" OFF)
 option(TARGET_INSTALL_PACKAGE_REQUIRE_SIGNING "Require GPG signing for ${PROJECT_NAME} CPack archives" OFF)
 set(GPG_SIGNING_KEY
     ""
@@ -38,9 +41,39 @@ set(GPG_PASSPHRASE_FILE
     CACHE FILEPATH "File containing the GPG key passphrase for noninteractive CPack signing")
 if(NOT TARGET_INSTALL_PACKAGE_DISABLE_INSTALL)
   if(PROJECT_IS_TOP_LEVEL OR TARGET_INSTALL_PACKAGE_ENABLE_INSTALL)
+    set(_tip_self_additional_target_args "")
+    set(_tip_self_sbom_args "")
+    if(TARGET_INSTALL_PACKAGE_ENABLE_SBOM)
+      set(_tip_self_helper_targets list_file_include_guard project_include_guard project_log)
+      foreach(_tip_self_helper_target IN LISTS _tip_self_helper_targets)
+        if(TARGET ${_tip_self_helper_target})
+          message(FATAL_ERROR "Cannot create self-release helper target '${_tip_self_helper_target}' because a target with that name already exists.")
+        endif()
+        add_library(${_tip_self_helper_target} INTERFACE)
+        set_target_properties(${_tip_self_helper_target} PROPERTIES SPDX_LICENSE "${target_install_package_SPDX_LICENSE}")
+      endforeach()
+      target_link_libraries(${PROJECT_NAME} INTERFACE ${_tip_self_helper_targets})
+      list(APPEND _tip_self_additional_target_args ADDITIONAL_TARGETS ${_tip_self_helper_targets})
+      list(
+        APPEND
+        _tip_self_sbom_args
+        SBOM
+        SBOM_NAME
+        ${PROJECT_NAME}
+        SBOM_DESTINATION
+        ${CMAKE_INSTALL_DATADIR}/sbom/${PROJECT_NAME}
+        SBOM_LICENSE
+        ${target_install_package_SPDX_LICENSE}
+        SBOM_DESCRIPTION
+        "${PROJECT_DESCRIPTION}"
+        SBOM_HOMEPAGE_URL
+        "${PROJECT_HOMEPAGE_URL}")
+    endif()
+
     # Use target_install_package to install itself and target_configure_sources
     target_install_package(
       ${PROJECT_NAME}
+      ${_tip_self_additional_target_args}
       ADDITIONAL_FILES
       ${CMAKE_CURRENT_LIST_DIR}/cmake/generic-config.cmake.in
       ${CMAKE_CURRENT_LIST_DIR}/cmake/sign_packages.cmake.in
@@ -62,7 +95,8 @@ if(NOT TARGET_INSTALL_PACKAGE_DISABLE_INSTALL)
       ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
       # Override include destination to put modules in the cmake dir
       INCLUDE_DESTINATION
-      ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME})
+      ${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}
+      ${_tip_self_sbom_args})
 
     install(
       PROGRAMS ${CMAKE_CURRENT_LIST_DIR}/cmake/build_minimal_container.sh ${CMAKE_CURRENT_LIST_DIR}/cmake/collect_runtime_deps.sh ${CMAKE_CURRENT_LIST_DIR}/cmake/container_to_quadlet.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 project(
   target_install_package
-  VERSION 7.0.4
+  VERSION 7.0.5
   DESCRIPTION "CMake utilities for creating installable packages"
   HOMEPAGE_URL "https://github.com/jkammerland/target_install_package.cmake")
 set(target_install_package_SPDX_LICENSE "MIT")

--- a/CPack-Tutorial.md
+++ b/CPack-Tutorial.md
@@ -217,7 +217,7 @@ cmake_minimum_required(VERSION 3.25)
 project(MyProject VERSION 1.2.0 DESCRIPTION "My awesome library package")
 
 # Include target_install_package() and export_cpack()
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.4 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.5 CONFIG REQUIRED)
 
 # Create targets (same as before)
 add_library(mylib SHARED src/mylib.cpp)
@@ -531,7 +531,7 @@ GPG_KEYSERVER "keys.corp.internal"
 cmake_minimum_required(VERSION 3.25)
 project(SecureLibrary VERSION 2.1.0)
 
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.4 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.5 CONFIG REQUIRED)
 
 # Create library targets
 add_library(secure_core SHARED src/core.cpp)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ include(FetchContent)
 FetchContent_Declare(
   target_install_package
   GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-  GIT_TAG v7.0.4
+  GIT_TAG v7.0.5
 )
 FetchContent_MakeAvailable(target_install_package)
 
@@ -202,7 +202,7 @@ if(${PROJECT_NAME}_INSTALL)
   FetchContent_Declare(
     target_install_package
     GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-    GIT_TAG v7.0.4
+    GIT_TAG v7.0.5
     # Optional arg to first try find_package locally before fetching, see manual installation
     # NOTE: This must be called last, with 0 to N args following FIND_PACKAGE_ARGS
     # FIND_PACKAGE_ARGS

--- a/ci/cmd/bootstrap.sh
+++ b/ci/cmd/bootstrap.sh
@@ -13,6 +13,7 @@ Usage: ci/run.sh bootstrap [options]
 
 Options:
   --ninja                 Ensure Ninja is installed
+  --cmake-version <ver>   Ensure an exact CMake version using Python's user install if needed
   --fmt                   Build+install fmt to a prefix
   --fmt-prefix <dir>      fmt install prefix (default: ./build/ci-deps/fmt-install)
   --fmt-ref <git-ref>     fmt git ref/sha (default: pinned commit)
@@ -30,6 +31,7 @@ ensure_ninja=false
 ensure_fmt=false
 ensure_packaging_tools=false
 ensure_gpg=false
+ensure_cmake_version=""
 
 fmt_prefix="${ci_root}/build/ci-deps/fmt-install"
 fmt_ref="53d006abfdc0653f7d3e4e180e694fcb720524b5"
@@ -47,6 +49,10 @@ while [[ $# -gt 0 ]]; do
     --ninja)
       ensure_ninja=true
       shift
+      ;;
+    --cmake-version)
+      ensure_cmake_version="${2:?}"
+      shift 2
       ;;
     --fmt)
       ensure_fmt=true
@@ -92,7 +98,21 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ -n "${ensure_cmake_version}" ]]; then
+  current_cmake_version=""
+  if ci_has_cmd cmake; then
+    current_cmake_version="$(cmake --version | awk 'NR == 1 { print $3 }')"
+  fi
+  if [[ "${current_cmake_version}" != "${ensure_cmake_version}" ]]; then
+    ci_python_bin="$(ci_python)" || ci_die "python is required to install CMake ${ensure_cmake_version}"
+    ci_log "Installing CMake ${ensure_cmake_version}..."
+    "${ci_python_bin}" -m pip install --user "cmake==${ensure_cmake_version}"
+    ci_add_path "${HOME}/.local/bin"
+  fi
+fi
+
 ci_require_cmd cmake
+cmake --version | head -n 1
 
 if [[ "${ensure_ninja}" == "true" ]]; then
   if ci_has_cmd ninja; then

--- a/ci/cmd/cpack.sh
+++ b/ci/cmd/cpack.sh
@@ -9,6 +9,8 @@ source "${ci_dir}/lib/common.sh"
 
 ci_setup_ccache "${ci_root}"
 
+tip_sbom_experimental_value="ca494ed3-b261-4205-a01f-603c95e4cae0"
+
 usage() {
   cat <<'EOF'
 Usage: ci/run.sh cpack [options]
@@ -100,6 +102,65 @@ EOF
   gpg --batch --generate-key "${ci_root}/build/ci-deps/key-gen-batch"
   gpg --list-keys ci-test@target-install-package.local >/dev/null
   export GPG_SIGNING_KEY="ci-test@target-install-package.local"
+}
+
+validate_self_release_sbom() {
+  local sbom_file="${1:?}"
+  local ci_python_bin=""
+  ci_python_bin="$(ci_python)" || ci_die "python is required to validate the self-release SBOM"
+
+  "${ci_python_bin}" - "${sbom_file}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    document = json.load(f)
+
+graph = document.get("@graph", [])
+spdx_documents = [
+    item for item in graph
+    if item.get("type") == "SpdxDocument" and item.get("name") == "target_install_package"
+]
+if len(spdx_documents) != 1:
+    raise SystemExit(f"expected one target_install_package SPDX document, got {len(spdx_documents)}")
+
+spdx_document = spdx_documents[0]
+if spdx_document.get("dataLicense") != "MIT":
+    raise SystemExit(f"expected SPDX dataLicense MIT, got {spdx_document.get('dataLicense')!r}")
+
+expected_roots = {
+    "target_install_package",
+    "list_file_include_guard",
+    "project_include_guard",
+    "project_log",
+}
+actual_roots = {item.get("name") for item in spdx_document.get("rootElement", [])}
+missing = sorted(expected_roots - actual_roots)
+if missing:
+    raise SystemExit(f"self-release SBOM missing root elements: {', '.join(missing)}")
+PY
+}
+
+sign_and_verify_self_release_sidecar() {
+  local sidecar_file="${1:?}"
+  local sidecar_name
+  sidecar_name="$(basename "${sidecar_file}")"
+
+  local gpg_cmd=(gpg --batch --yes --detach-sign --armor)
+  if [[ -n "${GPG_PASSPHRASE_FILE:-}" && -f "${GPG_PASSPHRASE_FILE}" ]]; then
+    gpg_cmd+=(--pinentry-mode loopback --passphrase-file "${GPG_PASSPHRASE_FILE}")
+  else
+    gpg_cmd+=(--pinentry-mode loopback "--passphrase=")
+  fi
+  gpg_cmd+=(--default-key "${GPG_SIGNING_KEY}" --output "${sidecar_file}.sig" "${sidecar_file}")
+  "${gpg_cmd[@]}"
+
+  (cd "${package_dir}" && sha256sum "${sidecar_name}" >"${sidecar_name}.sha256")
+  (cd "${package_dir}" && sha512sum "${sidecar_name}" >"${sidecar_name}.sha512")
+  gpg --verify "${sidecar_file}.sig" "${sidecar_file}" >/dev/null
+  (cd "${package_dir}" && sha256sum -c "${sidecar_name}.sha256")
+  (cd "${package_dir}" && sha512sum -c "${sidecar_name}.sha512")
 }
 
 enable_gpg_signing_in_cpack_basic() {
@@ -447,6 +508,8 @@ run_self_release() {
     -DPROJECT_LOG_COLORS=ON \
     -DTARGET_INSTALL_PACKAGE_ENABLE_INSTALL=ON \
     -DTARGET_INSTALL_PACKAGE_ENABLE_CPACK=ON \
+    -DTARGET_INSTALL_PACKAGE_ENABLE_SBOM=ON \
+    -DCMAKE_EXPERIMENTAL_GENERATE_SBOM="${tip_sbom_experimental_value}" \
     -DTARGET_INSTALL_PACKAGE_REQUIRE_SIGNING=ON
 
   ci_log "==> Build root self-release package"
@@ -513,6 +576,20 @@ run_self_release() {
   [[ -f "${extracted_prefix}/share/cmake/target_install_package/sign_packages.cmake.in" ]] \
     || ci_die "Extracted archive is missing sign_packages.cmake.in"
   [[ -f "${extracted_prefix}/share/doc/target_install_package/LICENSE" ]] || ci_die "Extracted archive is missing LICENSE"
+
+  shopt -s nullglob
+  local packaged_sbom_files=("${extracted_prefix}/share/sbom/target_install_package"/*.spdx.json)
+  shopt -u nullglob
+  if (( ${#packaged_sbom_files[@]} != 1 )); then
+    ci_die "Expected one packaged target_install_package SBOM, found ${#packaged_sbom_files[@]}"
+  fi
+
+  local package_stem sbom_sidecar
+  package_stem="$(basename "${tgz_packages[0]}" .tar.gz)"
+  sbom_sidecar="${package_dir}/${package_stem}.spdx.json"
+  cmake -E copy "${packaged_sbom_files[0]}" "${sbom_sidecar}"
+  validate_self_release_sbom "${sbom_sidecar}"
+  sign_and_verify_self_release_sidecar "${sbom_sidecar}"
 
   cat >"${consumer_dir}/CMakeLists.txt" <<'EOF'
 cmake_minimum_required(VERSION 3.25)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,7 +35,7 @@ graph TD
   - `*-consume`: `ci/run.sh examples --suite consume-*`
 - `packaging-tests.yml`: `ci/run.sh bootstrap --packaging-tools` → `ci/run.sh packaging-tests`
 - `cpack.yml`: `ci/run.sh bootstrap --packaging-tools --gpg` → `ci/run.sh cpack ...`
-- `release.yml`: imports the release GPG key, runs `ci/run.sh cpack --suite self-release --require-signing`, then uploads the signed artifacts to the tag's GitHub release
+- `release.yml`: installs CMake 4.3.1, imports the release GPG key, runs `ci/run.sh cpack --suite self-release --require-signing`, then uploads the signed archives, SPDX SBOM, signatures, checksums, and public verification key to the tag's GitHub release
 
 ## Local parity (common entrypoints)
 
@@ -45,7 +45,7 @@ graph TD
 - Examples: `bash ci/run.sh examples --suite single --build-type Release --use-fetchcontent`
 - Packaging: `bash ci/run.sh packaging-tests`
 - CPack: `bash ci/run.sh cpack --suite regression`
-- Self-release package dry run: `bash ci/run.sh bootstrap --ninja --gpg && bash ci/run.sh cpack --suite self-release`
+- Self-release package dry run: `bash ci/run.sh bootstrap --cmake-version 4.3.1 --ninja --gpg && bash ci/run.sh cpack --suite self-release`
 
 ## Logging and outputs
 

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -4,6 +4,8 @@ A Software Bill of Materials is a machine-readable inventory of what a package c
 
 `target_install_package(... SBOM ...)` keeps the normal CMake config package and additionally asks CMake to install an SPDX SBOM for the export when CMake's SBOM experiment is activated.
 
+The repository dogfoods this path for tagged releases. The self-release package exports an SPDX SBOM for the installed CMake module tree, includes the inlined helper modules as interface components, and publishes a signed sidecar named `target_install_package-<version>-cmake.spdx.json`.
+
 ## Basic Example
 
 ```cmake

--- a/export_cpack.cmake
+++ b/export_cpack.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.4)
+  list_file_include_guard(VERSION 7.0.5)
 else()
   if(COMMAND project_log)
     project_log(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")

--- a/target_configure_sources.cmake
+++ b/target_configure_sources.cmake
@@ -3,7 +3,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.4)
+  list_file_include_guard(VERSION 7.0.5)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.4)
+  list_file_include_guard(VERSION 7.0.5)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 


### PR DESCRIPTION
## Summary
- Enable the project self-release path to install a CMake-generated SPDX SBOM for the shipped CMake module tree.
- Model the inlined helper modules as SPDX-licensed interface components when SBOM generation is enabled.
- Publish the release SBOM as a signed sidecar with SHA256/SHA512 checksums, and include it in release artifacts.
- Pin the release/self-release CI bootstrap to CMake 4.3.1 so the SBOM experiment is available.

## Validation
- `cmake-format -c .cmake-format.py CMakeLists.txt --check`
- `bash -n ci/cmd/cpack.sh ci/cmd/bootstrap.sh`
- YAML parse for `.github/workflows/cpack.yml` and `.github/workflows/release.yml`
- `git diff --check`
- `bash ci/run.sh cpack --suite self-release`
- `cmake -S . -B build/sbom-release -DTARGET_INSTALL_PACKAGE_ENABLE_INSTALL=ON -Dtarget_install_package_BUILD_TESTS=ON && cmake --build build/sbom-release && ctest --test-dir build/sbom-release --output-on-failure && cmake --install build/sbom-release --prefix build/sbom-release/install`