### PR TITLE
Fix release tag verification command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
             exit 1
           fi
 
-          if ! tag_verify_output="$(git tag -v --raw "${GITHUB_REF_NAME}" 2>&1)"; then
+          if ! tag_verify_output="$(git verify-tag --raw "${GITHUB_REF_NAME}" 2>&1)"; then
             printf '%s\n' "${tag_verify_output}" >&2
             echo "Release tag ${GITHUB_REF_NAME} must be signed by the imported release GPG key" >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,54 @@ jobs:
             printf 'GPG_PASSPHRASE_FILE=%s\n' "${passphrase_file}" >> "${GITHUB_ENV}"
           fi
 
+      - name: Verify signed release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --force origin "+refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
+          tag_type="$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}")"
+          if [[ "${tag_type}" != "tag" ]]; then
+            echo "Release tag ${GITHUB_REF_NAME} must be an annotated signed tag; got ${tag_type}" >&2
+            exit 1
+          fi
+
+          if ! tag_verify_output="$(git tag -v --raw "${GITHUB_REF_NAME}" 2>&1)"; then
+            printf '%s\n' "${tag_verify_output}" >&2
+            echo "Release tag ${GITHUB_REF_NAME} must be signed by the imported release GPG key" >&2
+            exit 1
+          fi
+          printf '%s\n' "${tag_verify_output}"
+
+          tag_fingerprint="$(
+            awk '/^\[GNUPG:\] VALIDSIG / { print $3; exit }' <<< "${tag_verify_output}"
+          )"
+          if [[ -z "${tag_fingerprint}" ]]; then
+            echo "Could not determine ${GITHUB_REF_NAME} tag signing fingerprint" >&2
+            exit 1
+          fi
+
+          mapfile -t allowed_fingerprints < <(
+            gpg --batch --with-colons --list-secret-keys "${GPG_SIGNING_KEY}" | awk -F: '/^fpr:/ { print $10 }'
+          )
+          if (( ${#allowed_fingerprints[@]} == 0 )); then
+            echo "Could not determine allowed release signing fingerprints" >&2
+            exit 1
+          fi
+
+          fingerprint_matches=false
+          for allowed_fingerprint in "${allowed_fingerprints[@]}"; do
+            if [[ "${tag_fingerprint}" == "${allowed_fingerprint}" ]]; then
+              fingerprint_matches=true
+              break
+            fi
+          done
+          if [[ "${fingerprint_matches}" != "true" ]]; then
+            echo "Release tag ${GITHUB_REF_NAME} was signed by ${tag_fingerprint}, expected one of:" >&2
+            printf '  %s\n' "${allowed_fingerprints[@]}" >&2
+            exit 1
+          fi
+
       - name: Build signed release artifacts
         shell: bash
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 project(
   target_install_package
-  VERSION 7.0.5
+  VERSION 7.0.6
   DESCRIPTION "CMake utilities for creating installable packages"
   HOMEPAGE_URL "https://github.com/jkammerland/target_install_package.cmake")
 set(target_install_package_SPDX_LICENSE "MIT")

--- a/CPack-Tutorial.md
+++ b/CPack-Tutorial.md
@@ -217,7 +217,7 @@ cmake_minimum_required(VERSION 3.25)
 project(MyProject VERSION 1.2.0 DESCRIPTION "My awesome library package")
 
 # Include target_install_package() and export_cpack()
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.5 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.6 CONFIG REQUIRED)
 
 # Create targets (same as before)
 add_library(mylib SHARED src/mylib.cpp)
@@ -531,7 +531,7 @@ GPG_KEYSERVER "keys.corp.internal"
 cmake_minimum_required(VERSION 3.25)
 project(SecureLibrary VERSION 2.1.0)
 
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.5 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.6 CONFIG REQUIRED)
 
 # Create library targets
 add_library(secure_core SHARED src/core.cpp)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ include(FetchContent)
 FetchContent_Declare(
   target_install_package
   GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-  GIT_TAG v7.0.5
+  GIT_TAG v7.0.6
 )
 FetchContent_MakeAvailable(target_install_package)
 
@@ -202,7 +202,7 @@ if(${PROJECT_NAME}_INSTALL)
   FetchContent_Declare(
     target_install_package
     GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-    GIT_TAG v7.0.5
+    GIT_TAG v7.0.6
     # Optional arg to first try find_package locally before fetching, see manual installation
     # NOTE: This must be called last, with 0 to N args following FIND_PACKAGE_ARGS
     # FIND_PACKAGE_ARGS

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -35,7 +35,7 @@ graph TD
   - `*-consume`: `ci/run.sh examples --suite consume-*`
 - `packaging-tests.yml`: `ci/run.sh bootstrap --packaging-tools` → `ci/run.sh packaging-tests`
 - `cpack.yml`: `ci/run.sh bootstrap --packaging-tools --gpg` → `ci/run.sh cpack ...`
-- `release.yml`: installs CMake 4.3.1, imports the release GPG key, runs `ci/run.sh cpack --suite self-release --require-signing`, then uploads the signed archives, SPDX SBOM, signatures, checksums, and public verification key to the tag's GitHub release
+- `release.yml`: installs CMake 4.3.1, imports the release GPG key, verifies the tag is annotated and signed by that key, runs `ci/run.sh cpack --suite self-release --require-signing`, then uploads the signed archives, SPDX SBOM, signatures, checksums, and public verification key to the tag's GitHub release
 
 ## Local parity (common entrypoints)
 
@@ -46,6 +46,12 @@ graph TD
 - Packaging: `bash ci/run.sh packaging-tests`
 - CPack: `bash ci/run.sh cpack --suite regression`
 - Self-release package dry run: `bash ci/run.sh bootstrap --cmake-version 4.3.1 --ninja --gpg && bash ci/run.sh cpack --suite self-release`
+
+## Tagged releases
+
+Release assets are signed with the dedicated GPG key stored in the `GPG_PRIVATE_KEY`, `GPG_SIGNING_KEY`, and optional `GPG_PASSPHRASE` GitHub Actions secrets. The exported public key asset is generated from that key, so the key UID should identify this project and should not use placeholder contact information.
+
+Release tags must be annotated and signed by the same release key. The release workflow verifies both the tag signature and the signing fingerprint before it builds artifacts.
 
 ## Logging and outputs
 

--- a/export_cpack.cmake
+++ b/export_cpack.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.5)
+  list_file_include_guard(VERSION 7.0.6)
 else()
   if(COMMAND project_log)
     project_log(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")

--- a/target_configure_sources.cmake
+++ b/target_configure_sources.cmake
@@ -3,7 +3,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.5)
+  list_file_include_guard(VERSION 7.0.6)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.5)
+  list_file_include_guard(VERSION 7.0.6)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 


### PR DESCRIPTION
## Summary
- Replace invalid `git tag -v --raw` usage with `git verify-tag --raw` in the tagged release workflow.
- Keeps the signed-tag gate, but allows supported Git versions on Actions runners to emit raw GPG status for fingerprint parsing.

## Validation
- YAML parse for `.github/workflows/release.yml`
- `git diff --check`
- Local `git verify-tag --raw v7.0.6` now reaches the intended tag-signature check and reports the current tag is unsigned instead of failing on an invalid option.