### PR TITLE
chore(release): prepare v7.0.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 project(
   target_install_package
-  VERSION 7.0.7
+  VERSION 7.0.8
   DESCRIPTION "CMake utilities for creating installable packages"
   HOMEPAGE_URL "https://github.com/jkammerland/target_install_package.cmake")
 set(target_install_package_SPDX_LICENSE "MIT")

--- a/CPack-Tutorial.md
+++ b/CPack-Tutorial.md
@@ -217,7 +217,7 @@ cmake_minimum_required(VERSION 3.25)
 project(MyProject VERSION 1.2.0 DESCRIPTION "My awesome library package")
 
 # Include target_install_package() and export_cpack()
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.7 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.8 CONFIG REQUIRED)
 
 # Create targets (same as before)
 add_library(mylib SHARED src/mylib.cpp)
@@ -531,7 +531,7 @@ GPG_KEYSERVER "keys.corp.internal"
 cmake_minimum_required(VERSION 3.25)
 project(SecureLibrary VERSION 2.1.0)
 
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.7 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.8 CONFIG REQUIRED)
 
 # Create library targets
 add_library(secure_core SHARED src/core.cpp)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ include(FetchContent)
 FetchContent_Declare(
   target_install_package
   GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-  GIT_TAG v7.0.7
+  GIT_TAG v7.0.8
 )
 FetchContent_MakeAvailable(target_install_package)
 
@@ -221,7 +221,7 @@ include(FetchContent)
 FetchContent_Declare(
   target_install_package
   GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-  GIT_TAG v7.0.7
+  GIT_TAG v7.0.8
 )
 FetchContent_MakeAvailable(target_install_package)
 
@@ -238,7 +238,7 @@ if(${PROJECT_NAME}_INSTALL)
   FetchContent_Declare(
     target_install_package
     GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-    GIT_TAG v7.0.7
+    GIT_TAG v7.0.8
     # Optional arg to first try find_package locally before fetching, see manual installation
     # NOTE: This must be called last, with 0 to N args following FIND_PACKAGE_ARGS
     # FIND_PACKAGE_ARGS

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -47,7 +47,7 @@ graph TD
 - Packaging: `bash ci/run.sh packaging-tests`
 - CPack: `bash ci/run.sh cpack --suite regression`
 - Self-release package dry run: `bash ci/run.sh bootstrap --cmake-version 4.3.1 --ninja --gpg && bash ci/run.sh cpack --suite self-release`
-- Release tag verification: `bash ci/run.sh release verify-tag --tag v7.0.7 --trusted-ref refs/remotes/origin/master`
+- Release tag verification: `bash ci/run.sh release verify-tag --tag v7.0.8 --trusted-ref refs/remotes/origin/master`
 
 ## Tagged releases
 
@@ -55,7 +55,7 @@ Release assets are signed with the dedicated GPG key whose full fingerprint is `
 
 Release tags must be annotated, signed by that exact key, match the version in `CMakeLists.txt`, and point to a commit contained in `master`. The secret-free verification job enforces those conditions before the private-key job can start. The release job then checks that the tag still resolves to the verified commit before building.
 
-Configure the repository with an active tag ruleset matching `v*` that restricts tag creation, updates, and deletion to administrators. Configure the `release` environment with a required reviewer and allow only the protected `master` branch, because the trusted workflow is dispatched from `master` and verifies the tag input separately. Move the GPG secrets into that environment and remove their repository-level copies. Enable immutable releases before publishing the next version.
+Configure the repository with an active tag ruleset matching `v*` that restricts tag creation, updates, and deletion to administrators. Configure the `release` environment with a required reviewer and allow only the selected `master` branch, because the trusted workflow is dispatched from `master` and verifies the tag input separately. Move the GPG secrets into that environment and remove their repository-level copies. Enable immutable releases before publishing the next version.
 
 To publish a release:
 
@@ -64,7 +64,9 @@ To publish a release:
 3. Run the `Tagged Release` workflow from `master` with the tag name as its input.
 4. Review and approve the `release` environment deployment.
 
-The workflow creates a draft, uploads and verifies every asset, then publishes it. It refuses to replace assets on an existing published release.
+Do not create or publish the release through the GitHub Releases page. The workflow creates a draft, uploads and verifies every asset, then publishes it. It refuses to replace assets on an existing published release.
+
+Publishing makes the release, assets, and tag immutable. If an erroneous immutable release is deleted, GitHub permanently reserves its tag name; advance to a new version instead of trying to recreate that tag. Version `v7.0.7` is retired and must not be reused.
 
 ## Logging and outputs
 

--- a/export_cpack.cmake
+++ b/export_cpack.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.7)
+  list_file_include_guard(VERSION 7.0.8)
 else()
   if(COMMAND project_log)
     project_log(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")

--- a/target_configure_sources.cmake
+++ b/target_configure_sources.cmake
@@ -3,7 +3,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.7)
+  list_file_include_guard(VERSION 7.0.8)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.7)
+  list_file_include_guard(VERSION 7.0.8)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 


### PR DESCRIPTION
## Summary
- retire the unusable v7.0.7 release version and advance package metadata to v7.0.8
- update published FetchContent and find_package examples
- document workflow-only immutable release publication and permanent tag retirement

## Validation
- cmake-format --check CMakeLists.txt target_install_package.cmake target_configure_sources.cmake export_cpack.cmake
- cmake -S . -B /tmp/tip-v708-build -G Ninja -DTARGET_INSTALL_PACKAGE_ENABLE_INSTALL=ON -Dtarget_install_package_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release
- cmake --build /tmp/tip-v708-build
- ctest --test-dir /tmp/tip-v708-build --output-on-failure (38/38 passed)
- cmake --install /tmp/tip-v708-build --prefix /tmp/tip-v708-install
- bash ci/run.sh cpack --suite self-release --package-dir /tmp/tip-v708-release-packages