### PR TITLE
fix(release): retry immutable attestation verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,27 @@ jobs:
 
           gh release upload "${RELEASE_TAG}" "${release_assets[@]}" --clobber
           gh release edit "${RELEASE_TAG}" --draft=false
-          gh release verify "${RELEASE_TAG}"
+
+          release_verification_output=""
+          for attempt in {1..30}; do
+            if release_verification_output="$(gh release verify "${RELEASE_TAG}" 2>&1)"; then
+              printf '%s\n' "${release_verification_output}"
+              break
+            fi
+
+            printf '%s\n' "${release_verification_output}" >&2
+            if [[ "${release_verification_output}" != *"no attestations for tag"* ]]; then
+              exit 1
+            fi
+            if (( attempt == 30 )); then
+              echo "Release attestation was unavailable after 5 minutes" >&2
+              exit 1
+            fi
+
+            echo "Release attestation is not available yet; retrying in 10 seconds (${attempt}/30)" >&2
+            sleep 10
+          done
+
           for release_asset in "${release_assets[@]}"; do
             gh release verify-asset "${RELEASE_TAG}" "${release_asset}"
           done


### PR DESCRIPTION
## Summary
- retry immutable-release verification while GitHub propagates the attestation
- fail immediately for non-propagation verification errors
- cap retries at five minutes

## Validation
- `actionlint .github/workflows/release.yml`
- `yamllint .github/workflows/release.yml`
- mocked transient, fatal, and exhausted retry cases
- live `gh release verify v7.0.8`
- independent SHA-256, SHA-512, GPG, and GitHub attestation audit of every v7.0.8 asset