### PR TITLE
fix(sbom): support CMake 4.4 export syntax

### DIFF
--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -92,6 +92,45 @@ jobs:
           set -euxo pipefail
           bash ci/run.sh cpack --suite components
 
+  sbom-api-compatibility:
+    name: SBOM API (CMake ${{ matrix.cmake-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cmake-version: 4.3.1
+            activation-value: ca494ed3-b261-4205-a01f-603c95e4cae0
+          - cmake-version: 4.4.0
+            activation-value: 2d856d6d-53e8-488b-a17f-d486d2cac317
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bootstrap exact CMake and Ninja
+        shell: bash
+        run: |
+          set -euxo pipefail
+          bash ci/run.sh bootstrap \
+            --cmake-version "${{ matrix.cmake-version }}" \
+            --ninja
+
+      - name: Configure SBOM proof suite
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake -S . -B build/sbom-api -G Ninja \
+            -DTARGET_INSTALL_PACKAGE_DISABLE_INSTALL=ON \
+            -Dtarget_install_package_BUILD_TESTS=ON \
+            -Dtarget_install_package_PROOF_SBOM_EXPERIMENTAL_VALUE="${{ matrix.activation-value }}"
+
+      - name: Run SBOM proof suite
+        shell: bash
+        run: |
+          set -euxo pipefail
+          ctest --test-dir build/sbom-api \
+            --output-on-failure \
+            -R '^proof_sbom_'
+
   cpack-self-release:
     name: Self Release Package
     runs-on: ubuntu-latest

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,7 +10,7 @@ This matrix describes the supported surface of `target_install_package()`, `targ
 | `FILE_SET` header install flow | 3.25 | Public and interface header file sets are the preferred path. |
 | C++20 module file-set examples | 3.28 | Requires CMake module support and a compatible compiler/generator. |
 | Common Package Specification (`CPS`) | 4.3 | Uses CMake `install(PACKAGE_INFO)`. |
-| SPDX SBOM (`SBOM`) | 4.3 | Also requires `CMAKE_EXPERIMENTAL_GENERATE_SBOM` set to the activation value for the active CMake version. |
+| SPDX SBOM (`SBOM`) | 4.3 | Also requires `CMAKE_EXPERIMENTAL_GENERATE_SBOM` set to the activation value for the active CMake version. The wrapper supports CMake 4.3's `EXPORT` and CMake 4.4+'s `EXPORTS` signatures. |
 
 ## Target Types
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,7 +10,7 @@ This matrix describes the supported surface of `target_install_package()`, `targ
 | `FILE_SET` header install flow | 3.25 | Public and interface header file sets are the preferred path. |
 | C++20 module file-set examples | 3.28 | Requires CMake module support and a compatible compiler/generator. |
 | Common Package Specification (`CPS`) | 4.3 | Uses CMake `install(PACKAGE_INFO)`. |
-| SPDX SBOM (`SBOM`) | 4.3 | Also requires `CMAKE_EXPERIMENTAL_GENERATE_SBOM` set to the activation value for the active CMake version. The wrapper supports CMake 4.3's `EXPORT` and CMake 4.4+'s `EXPORTS` signatures. |
+| SPDX SBOM (`SBOM`) | 4.3 | Also requires `CMAKE_EXPERIMENTAL_GENERATE_SBOM` set to the activation value for the active CMake version. |
 
 ## Target Types
 

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -28,7 +28,6 @@ target_install_package(math_utils
 
 - `SBOM` is opt-in, export-scoped, and fails during configure on CMake older than 4.3.
 - This wrapper does not set `CMAKE_EXPERIMENTAL_GENERATE_SBOM` for you. The activation value is version-specific; use the value required by your CMake version.
-- CMake 4.3 spells the associated export option `EXPORT`; CMake 4.4 and newer spell it `EXPORTS`. The wrapper selects the compatible form automatically.
 - `SBOM_NAME` defaults to `EXPORT_NAME`.
 - `SBOM_VERSION` wins, then explicit wrapper `VERSION`, then selected/call-time project `VERSION`.
 - Wrapper effective `VERSION` fallback only applies when `SBOM_PROJECT` was not explicitly set.

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -1,6 +1,6 @@
 # Software Bill of Materials (SBOM)
 
-A Software Bill of Materials is a machine-readable inventory of what a package contains, including component names, versions, licenses, and related project metadata. Its purpose is supply-chain visibility: package managers, scanners, and compliance tooling can inspect what was shipped and connect it to license or vulnerability data. CMake 4.3 can generate installed SPDX SBOM metadata with [`install(SBOM)`](https://cmake.org/cmake/help/latest/command/install.html#sbom), and SPDX is documented by the [SPDX project](https://spdx.dev/).
+A Software Bill of Materials is a machine-readable inventory of what a package contains, including component names, versions, licenses, and related project metadata. Its purpose is supply-chain visibility: package managers, scanners, and compliance tooling can inspect what was shipped and connect it to license or vulnerability data. CMake 4.3+ can generate installed SPDX SBOM metadata with [`install(SBOM)`](https://cmake.org/cmake/help/latest/command/install.html#sbom), and SPDX is documented by the [SPDX project](https://spdx.dev/).
 
 `target_install_package(... SBOM ...)` keeps the normal CMake config package and additionally asks CMake to install an SPDX SBOM for the export when CMake's SBOM experiment is activated.
 
@@ -28,6 +28,7 @@ target_install_package(math_utils
 
 - `SBOM` is opt-in, export-scoped, and fails during configure on CMake older than 4.3.
 - This wrapper does not set `CMAKE_EXPERIMENTAL_GENERATE_SBOM` for you. The activation value is version-specific; use the value required by your CMake version.
+- CMake 4.3 spells the associated export option `EXPORT`; CMake 4.4 and newer spell it `EXPORTS`. The wrapper selects the compatible form automatically.
 - `SBOM_NAME` defaults to `EXPORT_NAME`.
 - `SBOM_VERSION` wins, then explicit wrapper `VERSION`, then selected/call-time project `VERSION`.
 - Wrapper effective `VERSION` fallback only applies when `SBOM_PROJECT` was not explicitly set.

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -1944,7 +1944,13 @@ function(finalize_package)
       set(_tip_sbom_effective_license "${SBOM_INHERITED_LICENSE}")
     endif()
 
-    set(_tip_sbom_args SBOM "${SBOM_NAME}" EXPORT "${ARG_EXPORT_NAME}")
+    # install(SBOM) is experimental, and CMake 4.4 replaced EXPORT with
+    # EXPORTS when it added support for aggregating multiple export sets.
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+      set(_tip_sbom_args SBOM "${SBOM_NAME}" EXPORTS "${ARG_EXPORT_NAME}")
+    else()
+      set(_tip_sbom_args SBOM "${SBOM_NAME}" EXPORT "${ARG_EXPORT_NAME}")
+    endif()
 
     if(SBOM_NO_PROJECT_METADATA
        OR SBOM_INHERITED_PROJECT_METADATA


### PR DESCRIPTION
## Summary

- emit CMake 4.3's `EXPORT` keyword for `install(SBOM)` on CMake 4.3
- emit CMake 4.4+'s `EXPORTS` keyword after the experimental API change
- run the existing end-to-end SBOM proof suite against exact CMake 4.3.1 and 4.4.0 versions in CI
- document that the wrapper abstracts the version-specific export signature

## Validation

- CMake 4.3.1 SBOM proof suite: 4/4 passed
- CMake 4.4.0 SBOM proof suite: 4/4 passed
- CMake 4.4.0 root build and install with the self-SBOM enabled
- general repository test suite: 38/38 passed
- `cmake-format --check -c .cmake-format.py target_install_package.cmake`
- Actionlint and yamllint for `.github/workflows/cpack.yml`
- `git diff --check`

The CMake developer warning remains expected because `install(SBOM)` is still an experimental interface.
