### PR TITLE
feat: Add CMake 4.4 package capabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,110 @@ on:
   workflow_dispatch:
 
 jobs:
+  cmake-feature-lanes:
+    name: CMake ${{ matrix.cmake-version }} (${{ matrix.feature }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cmake-version: 3.25.0
+            feature: core-floor
+          - cmake-version: 3.28.4
+            feature: modules-floor
+          - cmake-version: 4.4.2
+            feature: latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GCC 14 for the modules floor
+        if: matrix.feature == 'modules-floor'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y gcc-14 g++-14
+
+      - name: Bootstrap exact CMake and Ninja
+        shell: bash
+        run: |
+          set -euxo pipefail
+          bootstrap_args=(--cmake-version "${{ matrix.cmake-version }}" --ninja)
+          if [[ "${{ matrix.feature }}" != "modules-floor" ]]; then
+            bootstrap_args+=(--fmt)
+          fi
+          bash ci/run.sh bootstrap "${bootstrap_args[@]}"
+
+      - name: Prove the core CMake floor
+        if: matrix.feature == 'core-floor'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          bash ci/run.sh main --preset ci-release
+          bash ci/run.sh consumer --preset ci-release
+
+      - name: Prove the C++ modules floor
+        if: matrix.feature == 'modules-floor'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake -S examples/cxx-modules -B build/cmake-floor/modules -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc-14 \
+            -DCMAKE_CXX_COMPILER=g++-14 \
+            -DCMAKE_INSTALL_PREFIX="$PWD/build/cmake-floor/modules-install"
+          cmake --build build/cmake-floor/modules --target math_modules
+          cmake --install build/cmake-floor/modules
+
+      - name: Configure the latest CMake feature lane
+        if: matrix.feature == 'latest'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake -S . \
+            --presets-file cmake/presets/CMakePresets-4.4.json \
+            --preset ci-modern \
+            -DCMAKE_PREFIX_PATH="$PWD/build/ci-deps/fmt-install" \
+            -Werror=install-absolute-destination
+
+      - name: Build, test, and install the latest CMake feature lane
+        if: matrix.feature == 'latest'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake --build build/ci-modern
+          cmake --build build/ci-modern --target all_verify_header_sets
+          ctest --test-dir build/ci-modern --output-on-failure
+          cmake --install build/ci-modern
+
+  windows-clang-cl-modules:
+    name: CMake 4.4.2 modules (Windows / Ninja / clang-cl)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSVC Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Bootstrap exact CMake and Ninja
+        shell: bash
+        run: |
+          set -euxo pipefail
+          bash ci/run.sh bootstrap --cmake-version 4.4.2 --ninja
+
+      - name: Build and install the C++ modules example
+        shell: bash
+        run: |
+          set -euxo pipefail
+          clang-cl --version
+          cmake -S examples/cxx-modules -B build/clang-cl-modules -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=clang-cl \
+            -DCMAKE_CXX_COMPILER=clang-cl \
+            -DCMAKE_INSTALL_PREFIX="$PWD/build/clang-cl-modules-install"
+          cmake --build build/clang-cl-modules --target math_modules
+          cmake --install build/clang-cl-modules
+
   build:
     name: Build (${{ matrix.os }} / ${{ matrix.c_compiler }} / ${{ matrix.build_type }}${{ matrix.compiler_variant && format(' / {0}', matrix.compiler_variant) || '' }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -92,6 +92,35 @@ jobs:
           set -euxo pipefail
           bash ci/run.sh cpack --suite components
 
+  cpack-checksum-compatibility:
+    name: CPack checksums (CMake ${{ matrix.cmake-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake-version: [3.25.0, 4.2.3]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bootstrap exact CMake and Ninja
+        shell: bash
+        run: |
+          set -euxo pipefail
+          bash ci/run.sh bootstrap \
+            --cmake-version "${{ matrix.cmake-version }}" \
+            --ninja
+
+      - name: Prove fallback and native checksum generation
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake \
+            -DTIP_REPO_ROOT="$PWD" \
+            -DTIP_PROOF_TEST_ROOT="$PWD/build/cpack/checksums-${{ matrix.cmake-version }}" \
+            -DTIP_CMAKE_GENERATOR=Ninja \
+            -DTIP_CMAKE_MAKE_PROGRAM="$(command -v ninja)" \
+            -P tests/cmake/proof_cpack_checksums_test.cmake
+
   sbom-api-compatibility:
     name: SBOM API (CMake ${{ matrix.cmake-version }})
     runs-on: ubuntu-latest
@@ -99,9 +128,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cmake-version: 4.3.1
+          - cmake-version: 4.3.4
             activation-value: ca494ed3-b261-4205-a01f-603c95e4cae0
-          - cmake-version: 4.4.0
+          - cmake-version: 4.4.2
             activation-value: 2d856d6d-53e8-488b-a17f-d486d2cac317
     steps:
       - uses: actions/checkout@v4
@@ -141,7 +170,7 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          bash ci/run.sh bootstrap --cmake-version 4.3.1 --ninja --gpg
+          bash ci/run.sh bootstrap --cmake-version 4.4.2 --ninja --gpg
 
       - name: Build signed self-release package
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          bash ci/run.sh bootstrap --cmake-version 4.3.1 --ninja --gpg
+          bash ci/run.sh bootstrap --cmake-version 4.4.2 --ninja --gpg
 
       - name: Import release signing key
         shell: bash
@@ -158,8 +158,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          release_notes_source="docs/releases/${RELEASE_TAG}.md"
+          if [[ ! -f "${release_notes_source}" ]]; then
+            echo "Missing curated release notes: ${release_notes_source}" >&2
+            exit 1
+          fi
+
+          cat "${release_notes_source}" > build/release-notes.md
           {
-            echo "Signed target_install_package ${RELEASE_TAG} release artifacts."
+            echo
+            echo "## Artifact verification"
             echo
             echo "Assets include TGZ and ZIP install-tree archives, an SPDX SBOM, detached GPG signatures, SHA256/SHA512 checksums, and the exported public key for verifying release signatures."
             echo
@@ -171,7 +179,7 @@ jobs:
             echo "gpg --verify target_install_package-${RELEASE_VERSION}-cmake.spdx.json.sig target_install_package-${RELEASE_VERSION}-cmake.spdx.json"
             echo "sha256sum -c target_install_package-${RELEASE_VERSION}-cmake.tar.gz.sha256"
             echo '```'
-          } > build/release-notes.md
+          } >> build/release-notes.md
 
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 project(
   target_install_package
-  VERSION 7.0.8
+  VERSION 7.1.0
   DESCRIPTION "CMake utilities for creating installable packages"
   HOMEPAGE_URL "https://github.com/jkammerland/target_install_package.cmake")
 set(target_install_package_SPDX_LICENSE "MIT")
@@ -68,6 +68,9 @@ if(NOT TARGET_INSTALL_PACKAGE_DISABLE_INSTALL)
         "${PROJECT_DESCRIPTION}"
         SBOM_HOMEPAGE_URL
         "${PROJECT_HOMEPAGE_URL}")
+      if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+        list(APPEND _tip_self_sbom_args SBOM_PACKAGE_URL "pkg:github/jkammerland/target_install_package.cmake@${PROJECT_VERSION}")
+      endif()
     endif()
 
     # Use target_install_package to install itself and target_configure_sources

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 7,
+  "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
     "minor": 25,

--- a/CPack-Tutorial.md
+++ b/CPack-Tutorial.md
@@ -217,7 +217,7 @@ cmake_minimum_required(VERSION 3.25)
 project(MyProject VERSION 1.2.0 DESCRIPTION "My awesome library package")
 
 # Include target_install_package() and export_cpack()
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.8 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.1.0 CONFIG REQUIRED)
 
 # Create targets (same as before)
 add_library(mylib SHARED src/mylib.cpp)
@@ -542,7 +542,7 @@ GPG_KEYSERVER "keys.corp.internal"
 cmake_minimum_required(VERSION 3.25)
 project(SecureLibrary VERSION 2.1.0)
 
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.0.8 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.1.0 CONFIG REQUIRED)
 
 # Create library targets
 add_library(secure_core SHARED src/core.cpp)

--- a/CPack-Tutorial.md
+++ b/CPack-Tutorial.md
@@ -514,6 +514,17 @@ GENERATE_CHECKSUMS ON
 GENERATE_CHECKSUMS OFF
 ```
 
+`GENERATE_CHECKSUMS` is the compatibility form: `ON` selects `SHA256` and `SHA512`, while `OFF` disables wrapper-managed checksums. New configurations can select any CMake hash algorithms explicitly:
+
+```cmake
+CHECKSUMS
+  SHA256
+  SHA512
+  SHA3_256
+```
+
+`CHECKSUMS` and `GENERATE_CHECKSUMS` are mutually exclusive. CMake 4.2+ uses native `CPACK_PACKAGE_CHECKSUM` list support. Older CMake versions generate the same lowercase sidecars from the post-build script after package signing.
+
 #### GPG_KEYSERVER
 **Purpose**: Provides a keyserver value for verification tooling that you generate around the package. Signing itself uses the local GPG keyring and does not fetch keys.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ See the [Compatibility Matrix](docs/compatibility.md) for target type, platform,
 - Target-centric install API with less boilerplate
 - Package installation with CMake config and version file generation
 - Automatic install rules from `FILE_SET` headers and C++20 modules
+- Source-only packages from installable CMake 4.4 `SOURCES` file sets
 - Static, shared, interface, executable, and multi-target export support
 - Component-based installation with runtime/development/custom separation
 - Build variant support for debug/release/custom configurations

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ include(FetchContent)
 FetchContent_Declare(
   target_install_package
   GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-  GIT_TAG v7.0.8
+  GIT_TAG v7.1.0
 )
 FetchContent_MakeAvailable(target_install_package)
 
@@ -222,7 +222,7 @@ include(FetchContent)
 FetchContent_Declare(
   target_install_package
   GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-  GIT_TAG v7.0.8
+  GIT_TAG v7.1.0
 )
 FetchContent_MakeAvailable(target_install_package)
 
@@ -239,7 +239,7 @@ if(${PROJECT_NAME}_INSTALL)
   FetchContent_Declare(
     target_install_package
     GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-    GIT_TAG v7.0.8
+    GIT_TAG v7.1.0
     # Optional arg to first try find_package locally before fetching, see manual installation
     # NOTE: This must be called last, with 0 to N args following FIND_PACKAGE_ARGS
     # FIND_PACKAGE_ARGS

--- a/ci/cmd/cpack.sh
+++ b/ci/cmd/cpack.sh
@@ -9,7 +9,8 @@ source "${ci_dir}/lib/common.sh"
 
 ci_setup_ccache "${ci_root}"
 
-tip_sbom_experimental_value="ca494ed3-b261-4205-a01f-603c95e4cae0"
+tip_sbom_experimental_value_43="ca494ed3-b261-4205-a01f-603c95e4cae0"
+tip_sbom_experimental_value_44="2d856d6d-53e8-488b-a17f-d486d2cac317"
 
 usage() {
   cat <<'EOF'
@@ -85,6 +86,23 @@ done
 
 ci_require_cmd cmake
 
+tip_sbom_experimental_value() {
+  local cmake_version
+  cmake_version="$(cmake --version | awk 'NR == 1 { print $3 }')"
+
+  case "${cmake_version}" in
+    4.3.*)
+      printf '%s\n' "${tip_sbom_experimental_value_43}"
+      ;;
+    4.4.*)
+      printf '%s\n' "${tip_sbom_experimental_value_44}"
+      ;;
+    *)
+      ci_die "The self-release SBOM suite does not have an activation value for CMake ${cmake_version}"
+      ;;
+  esac
+}
+
 generate_test_gpg_key() {
   ci_require_cmd gpg
   cat >"${ci_root}/build/ci-deps/key-gen-batch" <<'EOF'
@@ -106,14 +124,16 @@ EOF
 
 validate_self_release_sbom() {
   local sbom_file="${1:?}"
+  local require_package_url="${2:-false}"
   local ci_python_bin=""
   ci_python_bin="$(ci_python)" || ci_die "python is required to validate the self-release SBOM"
 
-  "${ci_python_bin}" - "${sbom_file}" <<'PY'
+  "${ci_python_bin}" - "${sbom_file}" "${require_package_url}" <<'PY'
 import json
 import sys
 
 path = sys.argv[1]
+require_package_url = sys.argv[2] == "true"
 with open(path, "r", encoding="utf-8") as f:
     document = json.load(f)
 
@@ -139,6 +159,16 @@ actual_roots = {item.get("name") for item in spdx_document.get("rootElement", []
 missing = sorted(expected_roots - actual_roots)
 if missing:
     raise SystemExit(f"self-release SBOM missing root elements: {', '.join(missing)}")
+
+if require_package_url:
+    for root in spdx_document.get("rootElement", []):
+        version = root.get("software_packageVersion")
+        expected_url = f"pkg:github/jkammerland/target_install_package.cmake@{version}"
+        if root.get("software_downloadLocation") != expected_url:
+            raise SystemExit(
+                f"expected package URL {expected_url!r} for {root.get('name')}, "
+                f"got {root.get('software_downloadLocation')!r}"
+            )
 PY
 }
 
@@ -477,6 +507,9 @@ run_self_release() {
   ci_require_cmd cpack
   ci_require_cmd gpg
 
+  local sbom_experimental_value
+  sbom_experimental_value="$(tip_sbom_experimental_value)"
+
   if [[ "${require_signing}" == "true" && -z "${GPG_SIGNING_KEY:-}" ]]; then
     ci_die "--require-signing requires GPG_SIGNING_KEY to name an imported private key"
   fi
@@ -509,7 +542,7 @@ run_self_release() {
     -DTARGET_INSTALL_PACKAGE_ENABLE_INSTALL=ON \
     -DTARGET_INSTALL_PACKAGE_ENABLE_CPACK=ON \
     -DTARGET_INSTALL_PACKAGE_ENABLE_SBOM=ON \
-    -DCMAKE_EXPERIMENTAL_GENERATE_SBOM="${tip_sbom_experimental_value}" \
+    -DCMAKE_EXPERIMENTAL_GENERATE_SBOM="${sbom_experimental_value}" \
     -DTARGET_INSTALL_PACKAGE_REQUIRE_SIGNING=ON
 
   ci_log "==> Build root self-release package"
@@ -588,7 +621,11 @@ run_self_release() {
   package_stem="$(basename "${tgz_packages[0]}" .tar.gz)"
   sbom_sidecar="${package_dir}/${package_stem}.spdx.json"
   cmake -E copy "${packaged_sbom_files[0]}" "${sbom_sidecar}"
-  validate_self_release_sbom "${sbom_sidecar}"
+  local require_package_url=false
+  if [[ "${sbom_experimental_value}" == "${tip_sbom_experimental_value_44}" ]]; then
+    require_package_url=true
+  fi
+  validate_self_release_sbom "${sbom_sidecar}" "${require_package_url}"
   sign_and_verify_self_release_sidecar "${sbom_sidecar}"
 
   cat >"${consumer_dir}/CMakeLists.txt" <<'EOF'

--- a/cmake/presets/CMakePresets-4.4.json
+++ b/cmake/presets/CMakePresets-4.4.json
@@ -1,0 +1,42 @@
+{
+  "version": 12,
+  "cmakeMinimumRequired": {
+    "major": 4,
+    "minor": 4,
+    "patch": 2
+  },
+  "configurePresets": [
+    {
+      "name": "ci-modern",
+      "displayName": "CI modern CMake features",
+      "description": "CMake 4.4 proof suite with public and private header verification",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/ci-modern",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/ci-modern/install",
+        "CMAKE_VERIFY_INTERFACE_HEADER_SETS": "ON",
+        "CMAKE_VERIFY_PRIVATE_HEADER_SETS": "ON",
+        "PROJECT_LOG_COLORS": "ON",
+        "TARGET_INSTALL_PACKAGE_ENABLE_INSTALL": "ON",
+        "target_install_package_BUILD_PROOF_TESTS": "ON",
+        "target_install_package_BUILD_TESTS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ci-modern",
+      "configurePreset": "ci-modern"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "ci-modern",
+      "configurePreset": "ci-modern",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/cmake/sign_packages.cmake.in
+++ b/cmake/sign_packages.cmake.in
@@ -9,7 +9,7 @@ set(SIGNING_KEY "@ARG_SIGNING_KEY@")
 set(PASSPHRASE_FILE "@ARG_PASSPHRASE_FILE@")
 set(SIGNING_METHOD "@ARG_SIGNING_METHOD@")
 set(KEYSERVER "@ARG_KEYSERVER@")
-set(GENERATE_CHECKSUMS "@ARG_GENERATE_CHECKSUMS@")
+set(CHECKSUMS "@ARG_CHECKSUMS@")
 set(PACKAGE_NAME "@ARG_PACKAGE_NAME@")
 set(PACKAGE_VERSION "@ARG_PACKAGE_VERSION@")
 set(PACKAGE_CONTACT "@ARG_PACKAGE_CONTACT@")
@@ -63,8 +63,6 @@ set(embedded_signature_count 0)
 foreach(package_file ${PACKAGE_FILES})
   get_filename_component(package_name ${package_file} NAME)
   set(target_signature "${CPACK_PACKAGE_DIRECTORY}/${package_name}.sig")
-  set(target_sha256 "${CPACK_PACKAGE_DIRECTORY}/${package_name}.sha256")
-  set(target_sha512 "${CPACK_PACKAGE_DIRECTORY}/${package_name}.sha512")
 
   if(SIGNING_METHOD STREQUAL "none")
     message(STATUS "[GPG Signing] Processing ${package_name}...")
@@ -83,8 +81,25 @@ foreach(package_file ${PACKAGE_FILES})
     endforeach()
   endif()
 
-  if(NOT GENERATE_CHECKSUMS)
-    set(stale_checksum_files "${package_file}.sha256" "${target_sha256}" "${package_file}.sha512" "${target_sha512}")
+  set(_tip_supported_checksum_algorithms
+      MD5
+      SHA1
+      SHA224
+      SHA256
+      SHA384
+      SHA512
+      SHA3_224
+      SHA3_256
+      SHA3_384
+      SHA3_512)
+  set(stale_checksum_files "")
+  foreach(checksum_algorithm IN LISTS _tip_supported_checksum_algorithms)
+    if(NOT checksum_algorithm IN_LIST CHECKSUMS)
+      string(TOLOWER "${checksum_algorithm}" checksum_extension)
+      list(APPEND stale_checksum_files "${package_file}.${checksum_extension}" "${CPACK_PACKAGE_DIRECTORY}/${package_name}.${checksum_extension}")
+    endif()
+  endforeach()
+  if(stale_checksum_files)
     list(REMOVE_DUPLICATES stale_checksum_files)
     foreach(stale_checksum_file IN LISTS stale_checksum_files)
       if(EXISTS "${stale_checksum_file}")
@@ -161,36 +176,14 @@ foreach(package_file ${PACKAGE_FILES})
   endif()
 
   # Generate checksums if requested
-  if(GENERATE_CHECKSUMS)
+  if(CHECKSUMS)
     get_filename_component(package_basename "${package_file}" NAME)
-
-    # Generate SHA256
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E sha256sum "${package_file}"
-      OUTPUT_VARIABLE sha256_output
-      RESULT_VARIABLE sha256_result)
-
-    if(sha256_result EQUAL 0)
-      # Extract hash and normalize format for compatibility with sha256sum -c
-      string(REGEX MATCH "^[a-f0-9]+" sha256_hash "${sha256_output}")
-      # Create format compatible with sha256sum -c: "hash  filename"
-      file(WRITE "${package_file}.sha256" "${sha256_hash}  ${package_basename}\n")
-      message(STATUS "[GPG Signing] Created SHA256: ${package_name}.sha256 (${sha256_hash})")
-    endif()
-
-    # Generate SHA512
-    execute_process(
-      COMMAND ${CMAKE_COMMAND} -E sha512sum "${package_file}"
-      OUTPUT_VARIABLE sha512_output
-      RESULT_VARIABLE sha512_result)
-
-    if(sha512_result EQUAL 0)
-      # Extract hash and normalize format for compatibility with sha512sum -c
-      string(REGEX MATCH "^[a-f0-9]+" sha512_hash "${sha512_output}")
-      # Create format compatible with sha512sum -c: "hash  filename"
-      file(WRITE "${package_file}.sha512" "${sha512_hash}  ${package_basename}\n")
-      message(STATUS "[GPG Signing] Created SHA512: ${package_name}.sha512 (${sha512_hash})")
-    endif()
+    foreach(checksum_algorithm IN LISTS CHECKSUMS)
+      string(TOLOWER "${checksum_algorithm}" checksum_extension)
+      file(${checksum_algorithm} "${package_file}" checksum_hash)
+      file(WRITE "${package_file}.${checksum_extension}" "${checksum_hash}  ${package_basename}\n")
+      message(STATUS "[GPG Signing] Created ${checksum_algorithm}: ${package_name}.${checksum_extension} (${checksum_hash})")
+    endforeach()
   endif()
 endforeach()
 
@@ -209,8 +202,6 @@ foreach(package_file ${PACKAGE_FILES})
 
   # Target location is the same directory as the package (CPACK_PACKAGE_DIRECTORY)
   set(target_signature "${CPACK_PACKAGE_DIRECTORY}/${package_name}.sig")
-  set(target_sha256 "${CPACK_PACKAGE_DIRECTORY}/${package_name}.sha256")
-  set(target_sha512 "${CPACK_PACKAGE_DIRECTORY}/${package_name}.sha512")
 
   # Always copy to ensure fresh signatures on rebuilds
   if(EXISTS "${package_file}.sig")
@@ -218,17 +209,15 @@ foreach(package_file ${PACKAGE_FILES})
     message(STATUS "[GPG Signing] Copied ${package_name}.sig to package directory")
   endif()
 
-  if(GENERATE_CHECKSUMS)
-    if(EXISTS "${package_file}.sha256")
-      file(COPY_FILE "${package_file}.sha256" "${target_sha256}")
-      message(STATUS "[GPG Signing] Copied ${package_name}.sha256 to package directory")
+  foreach(checksum_algorithm IN LISTS CHECKSUMS)
+    string(TOLOWER "${checksum_algorithm}" checksum_extension)
+    set(checksum_file "${package_file}.${checksum_extension}")
+    set(target_checksum "${CPACK_PACKAGE_DIRECTORY}/${package_name}.${checksum_extension}")
+    if(EXISTS "${checksum_file}")
+      file(COPY_FILE "${checksum_file}" "${target_checksum}")
+      message(STATUS "[GPG Signing] Copied ${package_name}.${checksum_extension} to package directory")
     endif()
-
-    if(EXISTS "${package_file}.sha512")
-      file(COPY_FILE "${package_file}.sha512" "${target_sha512}")
-      message(STATUS "[GPG Signing] Copied ${package_name}.sha512 to package directory")
-    endif()
-  endif()
+  endforeach()
 endforeach()
 
 if(SIGNING_METHOD STREQUAL "none")

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -7,6 +7,8 @@ This repository’s GitHub Actions workflows are intentionally thin wrappers aro
 ```mermaid
 graph TD
   CI[.github/workflows/ci.yml] --> B[build (matrix)]
+  CI --> FL[CMake feature floors and latest]
+  CI --> WCL[Windows Ninja + clang-cl modules]
   B -->|needs| INT[test-integration]
   CI --> EX[test-examples (matrix)]
   CI --> CSM[multi-config-consume (matrix)]
@@ -21,6 +23,8 @@ graph TD
   CPK --> CPK3[cpack components]
   CPK --> CPK4[cross-platform validation]
   CPK --> CPK5[self-release package]
+  CPK --> CPK6[checksum compatibility]
+  CPK --> CPK7[SBOM API compatibility]
 
   REL[.github/workflows/release.yml] --> RELV[verify signed tag without secrets]
   RELV -->|release environment approval| REL1[signed self-release package]
@@ -30,12 +34,14 @@ graph TD
 ## Workflow → script mapping
 
 - `ci.yml`
+  - `cmake-feature-lanes`: exact CMake `3.25.0`, `3.28.4`, and `4.4.2` core, module, and latest-feature proofs
+  - `windows-clang-cl-modules`: CMake `4.4.2` with Ninja and `clang-cl`
   - `build`: `ci/run.sh bootstrap` → `ci/run.sh main` → `ci/run.sh consumer`
   - `test-integration`: `ci/run.sh consumer --suite integration`
   - `test-examples`: `ci/run.sh examples --suite {single|multi} --use-fetchcontent`
   - `*-consume`: `ci/run.sh examples --suite consume-*`
 - `packaging-tests.yml`: `ci/run.sh bootstrap --packaging-tools` → `ci/run.sh packaging-tests`
-- `cpack.yml`: `ci/run.sh bootstrap --packaging-tools --gpg` → `ci/run.sh cpack ...`
+- `cpack.yml`: package integration plus exact CMake `3.25.0` fallback checksums, `4.2.3` native checksums, and `4.3.4`/`4.4.2` SBOM syntax proofs
 - `release.yml`: when dispatched from the default branch, verifies an existing annotated tag with the pinned public key and confirms that its commit belongs to `master`; after release-environment approval, imports the private key, runs `ci/run.sh cpack --suite self-release --require-signing`, and publishes the signed archives, SPDX SBOM, signatures, checksums, and public verification key
 
 ## Local parity (common entrypoints)
@@ -46,8 +52,9 @@ graph TD
 - Examples: `bash ci/run.sh examples --suite single --build-type Release --use-fetchcontent`
 - Packaging: `bash ci/run.sh packaging-tests`
 - CPack: `bash ci/run.sh cpack --suite regression`
-- Self-release package dry run: `bash ci/run.sh bootstrap --cmake-version 4.3.1 --ninja --gpg && bash ci/run.sh cpack --suite self-release`
-- Release tag verification: `bash ci/run.sh release verify-tag --tag v7.0.8 --trusted-ref refs/remotes/origin/master`
+- Latest-feature preset: `cmake -S . --presets-file cmake/presets/CMakePresets-4.4.json --preset ci-modern -Werror=install-absolute-destination`
+- Self-release package dry run: `bash ci/run.sh bootstrap --cmake-version 4.4.2 --ninja --gpg && bash ci/run.sh cpack --suite self-release`
+- Release tag verification: `bash ci/run.sh release verify-tag --tag v7.1.0 --trusted-ref refs/remotes/origin/master`
 
 ## Tagged releases
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -8,6 +8,7 @@ This matrix describes the supported surface of `target_install_package()`, `targ
 |---------|---------------|-------|
 | Core utilities and examples | 3.25 | Required by the project. |
 | `FILE_SET` header install flow | 3.25 | Public and interface header file sets are the preferred path. |
+| `SOURCES` file-set install flow | 4.4 | Produces source-only packages whose consumers also require CMake 4.4+. |
 | C++20 module file-set examples | 3.28 | Requires CMake module support and a compatible compiler/generator. |
 | Common Package Specification (`CPS`) | 4.3 | Uses CMake `install(PACKAGE_INFO)`. |
 | SPDX SBOM (`SBOM`) | 4.3 | Also requires `CMAKE_EXPERIMENTAL_GENERATE_SBOM` set to the activation value for the active CMake version. |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -39,7 +39,7 @@ This matrix describes the supported surface of `target_install_package()`, `targ
 | Archive packages | Yes | CPack and selected archive generator, usually `TGZ` or `ZIP`. |
 | Native Linux packages | Yes | Debian/RPM packaging tools on the build host. |
 | Signed packages | Yes | GPG for detached signatures; RPM signing tools for embedded RPM signatures. |
-| Checksums | Yes | Enabled through `export_cpack(GENERATE_CHECKSUMS ON)` or release configuration. |
+| Checksums | Yes | `CHECKSUMS` accepts CMake's MD5, SHA1, SHA2, and SHA3 algorithms. `GENERATE_CHECKSUMS ON` remains an alias for SHA256 and SHA512. |
 | Container archives | Yes | Linux host plus `podman` or `docker`; uses the CPack External generator. |
 | CPS metadata | Yes | CMake 4.3+ and compatible target set. |
 | SBOM metadata | Yes | CMake 4.3+ with the CMake SBOM experiment activated. |

--- a/docs/releases/v7.1.0.md
+++ b/docs/releases/v7.1.0.md
@@ -1,0 +1,21 @@
+# target_install_package v7.1.0
+
+This release adds CMake 4.4 package capabilities while retaining CMake 3.25 as the minimum for the core install path.
+
+## Highlights
+
+- Adds `SamePatchVersion`, `SameFullVersion`, and `SemanticVersion` package compatibility modes on CMake 4.4 and newer.
+- Adds explicit `ARCH_INDEPENDENT` package version files and deprecates `ExactVersion` on CMake 4.4 in favor of the new precise modes.
+- Installs and exports public and interface `SOURCES` file sets with relocated consumer coverage and explicit source-only package guidance.
+- Aggregates multiple export sets into one CMake 4.4 SPDX SBOM and exposes `SBOM_PACKAGE_URL` where the CMake parser supports it.
+- Accepts one or more of CMake's ten hash algorithms through `export_cpack(CHECKSUMS ...)`, using native CPack generation on CMake 4.2 and newer and a compatible fallback on older releases.
+
+## Compatibility
+
+- The core package-install path remains compatible with CMake 3.25.
+- C++ module packaging remains gated on CMake 3.28 or newer.
+- CPS and the original SBOM path remain gated on CMake 4.3 or newer.
+- Source file sets, aggregate SBOMs, package URLs in SBOM output, and the new version compatibility modes require CMake 4.4 or newer.
+- CPS output is rejected for source-only packages because CPS does not currently prove an equivalent source-file-set representation.
+
+The release CI pins CMake 3.25.0, 3.28.4, 4.2.3, 4.3.4, and 4.4.2 so each documented feature boundary is tested directly.

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -21,6 +21,7 @@ target_install_package(math_utils
   SBOM_LICENSE "MIT"
   SBOM_DESCRIPTION "Math utility library"
   SBOM_HOMEPAGE_URL "https://example.com/math-utils"
+  SBOM_PACKAGE_URL "pkg:github/example/math-utils@1.2.3"
 )
 ```
 
@@ -34,12 +35,14 @@ target_install_package(math_utils
 - SBOM activation and inherited project metadata are resolved when `target_install_package()` is called. This allows subdirectory projects to set `CMAKE_EXPERIMENTAL_GENERATE_SBOM` locally and use `SBOM_PROJECT` or a matching `SBOM_NAME`/`EXPORT_NAME` without inheriting top-level project metadata during deferred finalization.
 - Selected project metadata is snapshotted by the wrapper and passed as explicit `install(SBOM)` fields with CMake project inheritance disabled. Inherited metadata covers project `VERSION`, `SPDX_LICENSE`, `DESCRIPTION`, and `HOMEPAGE_URL` when the matching `SBOM_*` option is not explicit.
 - All `target_install_package(... SBOM ...)` calls sharing one `EXPORT_NAME` must agree on every non-empty SBOM option, including metadata inheritance mode: same project metadata, `SBOM_NO_PROJECT_METADATA`, or explicit fields only.
+- On CMake 4.4+, calls for different exports that share one `SBOM_NAME` produce one aggregate document. Version, license, description, homepage URL, package URL, format, destination, metadata mode, and activation value must match across those exports.
+- CMake 4.3 supports only one export per `SBOM_NAME`; attempting cross-export aggregation fails during configuration.
 - `SBOM_PROJECT` and `SBOM_NO_PROJECT_METADATA` are mutually exclusive in a single call and conflict if mixed for the same export.
 - `SBOM_FORMAT` is omitted by default so CMake uses its current SPDX 3.0.1 JSON-LD output.
 - `install(SBOM)` has no `COMPONENT` option. SBOM files therefore participate in full installs and CMake's own default non-component behavior rather than this wrapper's development component routing. A component install such as `cmake --install <build-dir> --component Development` does not install the SBOM.
 - CMake cannot generate an SBOM for targets whose `LINK_LIBRARIES` or `INTERFACE_LINK_LIBRARIES` contain generator expressions unless those expressions are guarded by `$<LINK_ONLY:...>`.
 - CMake may emit a developer warning because SBOM generation is experimental. Use `-Wno-dev` if you want quieter configure output.
 - `SBOM_LICENSE` is package/project-level metadata. Per-target component licenses should be set with each target's `SPDX_LICENSE` property.
-- This wrapper intentionally does not expose `SBOM_PACKAGE_URL` yet while CMake's experimental SBOM interface stabilizes. Do not pass `SBOM_PACKAGE_URL`; it is not accepted or forwarded by this wrapper.
+- `SBOM_PACKAGE_URL` records the canonical package URL in the generated SPDX document and requires CMake 4.4+. CMake 4.3's documentation listed this option, but its command parser does not accept it.
 
 See [Default Installation Directories](default_install_dirs.md) for SBOM install destination defaults and component behavior.

--- a/docs/source-only-packages.md
+++ b/docs/source-only-packages.md
@@ -1,0 +1,50 @@
+# Source-only packages
+
+CMake 4.4 `SOURCES` file sets let a package install implementation sources as transitive usage requirements. `target_install_package()` installs every public or interface source set and exports it through the normal `Config.cmake` package:
+
+```cmake
+add_library(foo_sources INTERFACE)
+
+target_sources(foo_sources
+  INTERFACE
+    FILE_SET implementation
+    TYPE SOURCES
+    BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    FILES
+      src/foo.cpp
+      src/parser.cpp)
+
+target_install_package(foo_sources
+  NAMESPACE Foo::
+  SOURCE_DESTINATION "${CMAKE_INSTALL_DATADIR}/foo/src")
+```
+
+`SOURCE_DESTINATION` defaults to `${CMAKE_INSTALL_DATADIR}/${EXPORT_NAME}/src`. Source sets are installed in the development component and preserve their paths relative to `BASE_DIRS`. Both the producer and consumers of a source-only package require CMake 4.4 or newer. CPS output is rejected for exports containing source sets because CPS does not yet have a verified round trip for this metadata; the installed `Config.cmake` package is authoritative.
+
+Configured implementation sources use the same path:
+
+```cmake
+target_configure_sources(foo_sources
+  INTERFACE
+  FILE_SET generated_implementation
+  TYPE SOURCES
+  FILES src/configured_backend.cpp.in)
+```
+
+## Consumer build hygiene
+
+Interface sources are compiled into every dependent target. This model works well for small portability layers, generated implementations, and source packages that feed one final target. It is not a drop-in replacement for a static or shared library:
+
+- Multiple dependent libraries can compile the implementation more than once and produce duplicate external definitions.
+- Static state can be duplicated across binaries or shared libraries.
+- Consumer compile flags become part of the package's effective ABI.
+
+CMake 4.4 file-set properties can keep packaged sources out of consumer-wide tooling when appropriate:
+
+```cmake
+set_property(FILE_SET implementation TARGET foo_sources PROPERTY SKIP_LINTING ON)
+set_property(FILE_SET implementation TARGET foo_sources PROPERTY SKIP_PRECOMPILE_HEADERS ON)
+set_property(FILE_SET implementation TARGET foo_sources PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+```
+
+These controls are opt-in because some packages should inherit the consumer's analysis, precompiled-header, or unity-build settings.

--- a/export_cpack.cmake
+++ b/export_cpack.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.8)
+  list_file_include_guard(VERSION 7.1.0)
 else()
   if(COMMAND project_log)
     project_log(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")

--- a/export_cpack.cmake
+++ b/export_cpack.cmake
@@ -78,6 +78,7 @@ endif()
 #     [SIGNING_METHOD <detached|embedded|both>]
 #     [GPG_KEYSERVER <keyserver_url>]
 #     [GENERATE_CHECKSUMS]
+#     [CHECKSUMS <algorithm1> <algorithm2> ...]
 #     [CONTAINER_NAME <name>]
 #     [CONTAINER_TAG <tag>]
 #     [CONTAINER_RUNTIME <podman|docker>]
@@ -105,6 +106,8 @@ endif()
 #   ENABLE_COMPONENT_INSTALL - Force component-based installation
 #   ARCHIVE_FORMAT          - Format for archive generators (TGZ, ZIP, etc.)
 #   NO_DEFAULT_GENERATORS   - Don't set default generators based on platform
+#   CHECKSUMS               - Package checksum algorithms. Supports MD5, SHA1, SHA2, and SHA3 variants accepted by CMake.
+#   GENERATE_CHECKSUMS      - Compatibility alias: ON selects SHA256 and SHA512; OFF selects none. Cannot be combined with CHECKSUMS.
 #   CONTAINER_NAME          - Name for container image when using CONTAINER generator (default: lowercase package name)
 #   CONTAINER_TAG           - Tag for container image when using CONTAINER generator (default: package version)
 #   CONTAINER_RUNTIME       - Explicit runtime command for container build/save (default: podman)
@@ -879,6 +882,7 @@ function(_execute_deferred_cpack_config)
       SIGNING_METHOD
       GPG_KEYSERVER
       GENERATE_CHECKSUMS
+      CHECKSUMS
       CONTAINER_NAME
       CONTAINER_TAG
       CONTAINER_RUNTIME
@@ -937,6 +941,18 @@ function(_execute_deferred_cpack_config)
   endwhile()
 
   # Now parse and process the stored arguments
+  set(_tip_checksums_explicit FALSE)
+  set(_tip_legacy_checksums_explicit FALSE)
+  if("CHECKSUMS" IN_LIST _tip_cpack_parse_args)
+    set(_tip_checksums_explicit TRUE)
+  endif()
+  if("GENERATE_CHECKSUMS" IN_LIST _tip_cpack_parse_args)
+    set(_tip_legacy_checksums_explicit TRUE)
+  endif()
+  if(_tip_checksums_explicit AND _tip_legacy_checksums_explicit)
+    project_log(FATAL_ERROR "CHECKSUMS and GENERATE_CHECKSUMS cannot be used together. Use CHECKSUMS for an explicit algorithm list.")
+  endif()
+
   set(options COMPONENT_GROUPS ENABLE_COMPONENT_INSTALL NO_DEFAULT_GENERATORS)
   set(oneValueArgs
       PACKAGE_NAME
@@ -958,7 +974,7 @@ function(_execute_deferred_cpack_config)
       CONTAINER_RUNTIME
       CONTAINER_ENTRYPOINT
       CONTAINER_ARCHIVE_FORMAT)
-  set(multiValueArgs GENERATORS COMPONENTS DEFAULT_COMPONENTS CONTAINER_COMPONENTS CONTAINER_ROOTFS_OVERLAYS)
+  set(multiValueArgs GENERATORS COMPONENTS DEFAULT_COMPONENTS CHECKSUMS CONTAINER_COMPONENTS CONTAINER_ROOTFS_OVERLAYS)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${_tip_cpack_parse_args})
   if(_tip_additional_cpack_vars_seen)
     set(ARG_ADDITIONAL_CPACK_VARS "${_tip_additional_cpack_vars}")
@@ -966,6 +982,27 @@ function(_execute_deferred_cpack_config)
   if(ARG_UNPARSED_ARGUMENTS)
     project_log(FATAL_ERROR "Unknown arguments for export_cpack(): ${ARG_UNPARSED_ARGUMENTS}")
   endif()
+
+  set(_tip_supported_checksum_algorithms
+      MD5
+      SHA1
+      SHA224
+      SHA256
+      SHA384
+      SHA512
+      SHA3_224
+      SHA3_256
+      SHA3_384
+      SHA3_512)
+  set(_tip_explicit_checksum_algorithms "")
+  foreach(_tip_checksum_algorithm IN LISTS ARG_CHECKSUMS)
+    string(TOUPPER "${_tip_checksum_algorithm}" _tip_checksum_algorithm)
+    if(NOT _tip_checksum_algorithm IN_LIST _tip_supported_checksum_algorithms)
+      project_log(FATAL_ERROR "Unsupported CHECKSUMS algorithm '${_tip_checksum_algorithm}'. Supported values: ${_tip_supported_checksum_algorithms}")
+    endif()
+    list(APPEND _tip_explicit_checksum_algorithms "${_tip_checksum_algorithm}")
+  endforeach()
+  list(REMOVE_DUPLICATES _tip_explicit_checksum_algorithms)
   set(_tip_components_explicit FALSE)
   set(_tip_components_keyword "COMPONENTS")
   if(_tip_components_keyword IN_LIST _tip_cpack_parse_args)
@@ -1467,6 +1504,33 @@ function(_execute_deferred_cpack_config)
     set(_tip_gpg_requires_rpmsign TRUE)
   endif()
 
+  set(_tip_effective_signing_key "${ARG_GPG_SIGNING_KEY}")
+  if("${_tip_effective_signing_key}" STREQUAL "" AND DEFINED ENV{GPG_SIGNING_KEY})
+    set(_tip_effective_signing_key "$ENV{GPG_SIGNING_KEY}")
+  endif()
+
+  if(_tip_checksums_explicit)
+    set(_tip_checksum_algorithms ${_tip_explicit_checksum_algorithms})
+  elseif(_tip_legacy_checksums_explicit)
+    if(ARG_GENERATE_CHECKSUMS)
+      set(_tip_checksum_algorithms SHA256 SHA512)
+    else()
+      set(_tip_checksum_algorithms "")
+    endif()
+  elseif(NOT "${_tip_effective_signing_key}" STREQUAL "")
+    set(_tip_checksum_algorithms SHA256 SHA512)
+  else()
+    set(_tip_checksum_algorithms "")
+  endif()
+
+  set(_tip_post_build_checksum_algorithms ${_tip_checksum_algorithms})
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.2")
+    if(_tip_checksum_algorithms)
+      _tip_store_cpack_var(CPACK_PACKAGE_CHECKSUM "${_tip_checksum_algorithms}")
+    endif()
+    set(_tip_post_build_checksum_algorithms "")
+  endif()
+
   set(_tip_gpg_signing_args
       SIGNING_KEY
       "${ARG_GPG_SIGNING_KEY}"
@@ -1482,8 +1546,8 @@ function(_execute_deferred_cpack_config)
       "${ARG_PACKAGE_VERSION}"
       PACKAGE_CONTACT
       "${ARG_PACKAGE_CONTACT}")
-  if(DEFINED ARG_GENERATE_CHECKSUMS AND NOT "${ARG_GENERATE_CHECKSUMS}" STREQUAL "")
-    list(APPEND _tip_gpg_signing_args GENERATE_CHECKSUMS "${ARG_GENERATE_CHECKSUMS}")
+  if(_tip_post_build_checksum_algorithms)
+    list(APPEND _tip_gpg_signing_args CHECKSUMS ${_tip_post_build_checksum_algorithms})
   endif()
   if(_tip_gpg_requires_rpmsign)
     list(APPEND _tip_gpg_signing_args REQUIRE_RPMSIGN)
@@ -1544,11 +1608,10 @@ function(_configure_gpg_signing)
       PASSPHRASE_FILE
       SIGNING_METHOD
       KEYSERVER
-      GENERATE_CHECKSUMS
       PACKAGE_NAME
       PACKAGE_VERSION
       PACKAGE_CONTACT)
-  set(multiValueArgs)
+  set(multiValueArgs CHECKSUMS)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     project_log(FATAL_ERROR "Unknown arguments for GPG signing configuration: ${ARG_UNPARSED_ARGUMENTS}")
@@ -1563,24 +1626,6 @@ function(_configure_gpg_signing)
     set(ARG_PASSPHRASE_FILE "$ENV{GPG_PASSPHRASE_FILE}")
   endif()
 
-  # Enable checksums by default when signing is enabled. Without signing, only configure the post-build script when checksums were explicitly requested.
-  if(NOT DEFINED ARG_GENERATE_CHECKSUMS OR "${ARG_GENERATE_CHECKSUMS}" STREQUAL "")
-    if(ARG_SIGNING_KEY)
-      set(ARG_GENERATE_CHECKSUMS ON)
-    else()
-      set(ARG_GENERATE_CHECKSUMS OFF)
-    endif()
-  else()
-    string(TOUPPER "${ARG_GENERATE_CHECKSUMS}" _tip_generate_checksums_upper)
-    if(_tip_generate_checksums_upper MATCHES "^(ON|TRUE|YES|1)$")
-      set(ARG_GENERATE_CHECKSUMS ON)
-    elseif(_tip_generate_checksums_upper MATCHES "^(OFF|FALSE|NO|0)$")
-      set(ARG_GENERATE_CHECKSUMS OFF)
-    else()
-      project_log(FATAL_ERROR "GENERATE_CHECKSUMS must be ON or OFF, got: ${ARG_GENERATE_CHECKSUMS}")
-    endif()
-  endif()
-
   if(ARG_SIGNING_METHOD
      AND NOT ARG_SIGNING_METHOD STREQUAL "detached"
      AND NOT ARG_SIGNING_METHOD STREQUAL "embedded"
@@ -1592,7 +1637,7 @@ function(_configure_gpg_signing)
     project_log(FATAL_ERROR "SIGNING_METHOD '${ARG_SIGNING_METHOD}' requires GPG_SIGNING_KEY or the GPG_SIGNING_KEY environment variable.")
   endif()
 
-  if(NOT ARG_SIGNING_KEY AND NOT ARG_GENERATE_CHECKSUMS)
+  if(NOT ARG_SIGNING_KEY AND NOT ARG_CHECKSUMS)
     return()
   endif()
 
@@ -1669,11 +1714,11 @@ function(_configure_gpg_signing)
     project_log(STATUS "GPG package signing configured:")
     project_log(STATUS "  Signing key: ${ARG_SIGNING_KEY}")
     project_log(STATUS "  Signing method: ${ARG_SIGNING_METHOD}")
-    project_log(STATUS "  Generate checksums: ${ARG_GENERATE_CHECKSUMS}")
+    project_log(STATUS "  Post-build checksums: ${ARG_CHECKSUMS}")
     project_log(STATUS "  Post-build script: ${CMAKE_BINARY_DIR}/sign_packages.cmake")
   else()
     project_log(STATUS "CPack checksum generation configured:")
-    project_log(STATUS "  Generate checksums: ${ARG_GENERATE_CHECKSUMS}")
+    project_log(STATUS "  Post-build checksums: ${ARG_CHECKSUMS}")
     project_log(STATUS "  Post-build script: ${CMAKE_BINARY_DIR}/sign_packages.cmake")
   endif()
 

--- a/target_configure_sources.cmake
+++ b/target_configure_sources.cmake
@@ -3,7 +3,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.8)
+  list_file_include_guard(VERSION 7.1.0)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 

--- a/target_configure_sources.cmake
+++ b/target_configure_sources.cmake
@@ -25,7 +25,7 @@ endif()
 #     OUTPUT_DIR <directory>
 #     SUBSTITUTION_MODE @ONLY|VARIABLES
 #     FILE_SET <file_set_name>
-#     TYPE HEADERS
+#     TYPE <HEADERS|SOURCES>
 #     BASE_DIRS <base_directories...>
 #     FILES <template_files...>)
 #
@@ -35,7 +35,7 @@ endif()
 #   OUTPUT_DIR              - Directory for generated files (default: configured/TARGET_NAME).
 #   SUBSTITUTION_MODE       - Configure mode (@ONLY or VARIABLES, default: @ONLY).
 #   FILE_SET                - Name of the file set (default: HEADERS).
-#   TYPE                    - Type of file set (currently only HEADERS is supported).
+#   TYPE                    - Type of file set (HEADERS by default; SOURCES requires CMake 4.4+).
 #   BASE_DIRS               - Base directories for the file set; relative paths use CMAKE_CURRENT_BINARY_DIR (default: OUTPUT_DIR).
 #   FILES                   - List of template files to configure.
 #
@@ -137,8 +137,10 @@ function(target_configure_sources TARGET_NAME)
   endif()
 
   # Validate file set type
-  if(NOT ARGS_TYPE STREQUAL "HEADERS")
-    project_log(WARNING "target_configure_sources: Only HEADERS type is currently well-tested")
+  if(ARGS_TYPE STREQUAL "SOURCES" AND CMAKE_VERSION VERSION_LESS "4.4")
+    project_log(FATAL_ERROR "target_configure_sources: TYPE SOURCES requires CMake 4.4 or newer")
+  elseif(NOT ARGS_TYPE STREQUAL "HEADERS" AND NOT ARGS_TYPE STREQUAL "SOURCES")
+    project_log(WARNING "target_configure_sources: TYPE ${ARGS_TYPE} is not officially supported")
   endif()
 
   if(NOT ARGS_BASE_DIRS)
@@ -249,9 +251,13 @@ function(target_configure_sources TARGET_NAME)
   endif()
 
   get_target_property(TARGET_TYPE ${TARGET_NAME} TYPE)
-  if(NOT TARGET_TYPE STREQUAL "EXECUTABLE")
-    project_log(DEBUG "  Adding ${SCOPE} headers to FILE_SET ${ARGS_FILE_SET}")
+  if(NOT TARGET_TYPE STREQUAL "EXECUTABLE" OR ARGS_TYPE STREQUAL "SOURCES")
+    project_log(DEBUG "  Adding ${SCOPE} ${ARGS_TYPE} files to FILE_SET ${ARGS_FILE_SET}")
 
+    if(ARGS_TYPE STREQUAL "SOURCES")
+      cmake_policy(PUSH)
+      cmake_policy(SET CMP0211 NEW)
+    endif()
     target_sources(
       ${TARGET_NAME}
       ${SCOPE}
@@ -263,6 +269,9 @@ function(target_configure_sources TARGET_NAME)
       ${ARGS_BASE_DIRS}
       FILES
       ${CONFIGURED_FILES})
+    if(ARGS_TYPE STREQUAL "SOURCES")
+      cmake_policy(POP)
+    endif()
     list(LENGTH CONFIGURED_FILES FILE_COUNT)
     project_log(DEBUG "  Successfully added ${FILE_COUNT} files to FILE_SET ${ARGS_FILE_SET}")
   else()

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -57,6 +57,7 @@ endif()
 #     CONFIG_TEMPLATE <template_path>
 #     INCLUDE_DESTINATION <include_dest>
 #     MODULE_DESTINATION <module_dest>
+#     SOURCE_DESTINATION <source_dest>
 #     CMAKE_CONFIG_DESTINATION <config_dest>
 #     COMPONENT <component>
 #     DEBUG_POSTFIX <postfix>
@@ -115,6 +116,7 @@ endif()
 #                                  docs/template_resolution.md#source-of-truth
 #   INCLUDE_DESTINATION          - Destination for installed headers (default: `${CMAKE_INSTALL_INCLUDEDIR}`).
 #   MODULE_DESTINATION           - Destination for C++20 modules (default: `${CMAKE_INSTALL_INCLUDEDIR}`).
+#   SOURCE_DESTINATION           - Destination for CMake 4.4 SOURCES file sets (default: `${CMAKE_INSTALL_DATADIR}/${EXPORT_NAME}/src`).
 #   CMAKE_CONFIG_DESTINATION     - Destination for CMake config files (default: `${CMAKE_INSTALL_DATADIR}/cmake/${EXPORT_NAME}`).
 #   COMPONENT                    - Optional runtime component name. Development files stay in the shared `Development` component.
 #                                  If omitted, uses default "Runtime" and "Development" components.
@@ -143,6 +145,7 @@ endif()
 # Behavior:
 #   - Installs headers, libraries, and config files for the target.
 #   - Handles both legacy PUBLIC_HEADER and modern FILE_SET installation.
+#   - Installs public and interface SOURCES file sets with CMake 4.4+.
 #   - Supports C++20 modules (CMake 3.28+).
 #   - Generates CMake config files with version and dependency handling.
 #   - Supports multi-config builds with automatic debug postfix handling.
@@ -418,6 +421,7 @@ endfunction()
 #     CONFIG_TEMPLATE <template_path>
 #     INCLUDE_DESTINATION <include_dest>
 #     MODULE_DESTINATION <module_dest>
+#     SOURCE_DESTINATION <source_dest>
 #     CMAKE_CONFIG_DESTINATION <config_dest>
 #     COMPONENT <component>
 #     DEBUG_POSTFIX <postfix>
@@ -491,6 +495,7 @@ function(target_prepare_package TARGET_NAME)
       CONFIG_TEMPLATE
       INCLUDE_DESTINATION
       MODULE_DESTINATION
+      SOURCE_DESTINATION
       CMAKE_CONFIG_DESTINATION
       COMPONENT
       DEBUG_POSTFIX
@@ -642,6 +647,14 @@ function(target_prepare_package TARGET_NAME)
     endif()
     set(ARG_CMAKE_CONFIG_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/${ARG_EXPORT_NAME}")
     project_log(DEBUG "  CMake config destination not provided, using default: ${ARG_CMAKE_CONFIG_DESTINATION}")
+  endif()
+
+  if(NOT ARG_SOURCE_DESTINATION)
+    if(NOT CMAKE_INSTALL_DATADIR)
+      set(CMAKE_INSTALL_DATADIR "share")
+    endif()
+    set(ARG_SOURCE_DESTINATION "${CMAKE_INSTALL_DATADIR}/${ARG_EXPORT_NAME}/src")
+    project_log(DEBUG "  Source destination not provided, using default: ${ARG_SOURCE_DESTINATION}")
   endif()
 
   # BREAKING CHANGE: Validate against deprecated component names Users should use COMPONENT instead for cleaner naming
@@ -942,6 +955,7 @@ function(target_prepare_package TARGET_NAME)
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "CONFIG_TEMPLATE" "${ARG_CONFIG_TEMPLATE}" "config template")
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "INCLUDE_DESTINATION" "${ARG_INCLUDE_DESTINATION}" "include destination")
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "MODULE_DESTINATION" "${ARG_MODULE_DESTINATION}" "module destination")
+  _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "SOURCE_DESTINATION" "${ARG_SOURCE_DESTINATION}" "source destination")
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "CMAKE_CONFIG_DESTINATION" "${ARG_CMAKE_CONFIG_DESTINATION}" "CMake config destination")
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "DEBUG_POSTFIX" "${ARG_DEBUG_POSTFIX}" "debug postfix")
 
@@ -1468,6 +1482,7 @@ function(finalize_package)
   get_property(CONFIG_TEMPLATE GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_CONFIG_TEMPLATE")
   get_property(INCLUDE_DESTINATION GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_INCLUDE_DESTINATION")
   get_property(MODULE_DESTINATION GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_MODULE_DESTINATION")
+  get_property(SOURCE_DESTINATION GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_SOURCE_DESTINATION")
   get_property(CMAKE_CONFIG_DESTINATION GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_CMAKE_CONFIG_DESTINATION")
   get_property(CONFIG_DEV_COMPONENT GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_CONFIG_DEVELOPMENT_COMPONENT")
   get_property(CURRENT_SOURCE_DIR GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_CURRENT_SOURCE_DIR")
@@ -1609,6 +1624,7 @@ function(finalize_package)
   set(_tip_exported_alias_names "")
 
   # Install each target separately with its own components
+  set(_tip_export_has_source_sets FALSE)
   foreach(TARGET_NAME ${TARGETS})
     get_property(TARGET_RUNTIME_COMP GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_RUNTIME_COMPONENT")
     get_property(TARGET_DEV_COMP GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_DEVELOPMENT_COMPONENT")
@@ -1733,6 +1749,29 @@ function(finalize_package)
 
     if(TARGET_PUBLIC_HEADERS)
       list(APPEND INSTALL_ARGS PUBLIC_HEADER DESTINATION ${INCLUDE_DESTINATION} ${TARGET_DEV_COMPONENT_ARGS})
+    endif()
+
+    # Handle installable source file sets. All public and interface file sets must be listed when the target is exported.
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+      get_target_property(TARGET_INTERFACE_SOURCE_SETS ${TARGET_NAME} INTERFACE_SOURCE_SETS)
+      if(TARGET_INTERFACE_SOURCE_SETS AND NOT TARGET_INTERFACE_SOURCE_SETS MATCHES "-NOTFOUND$")
+        set(_tip_export_has_source_sets TRUE)
+        if(CPS_ENABLED)
+          project_log(
+            FATAL_ERROR
+            "CPS package metadata for export '${ARG_EXPORT_NAME}' is not supported with SOURCES file sets. Use the authoritative Config.cmake export or move source-only targets to a non-CPS export.")
+        endif()
+        foreach(CURRENT_SOURCE_SET_NAME IN LISTS TARGET_INTERFACE_SOURCE_SETS)
+          list(
+            APPEND
+            INSTALL_ARGS
+            FILE_SET
+            "${CURRENT_SOURCE_SET_NAME}"
+            DESTINATION
+            "${SOURCE_DESTINATION}"
+            ${TARGET_DEV_COMPONENT_ARGS})
+        endforeach()
+      endif()
     endif()
 
     # Handle C++20 modules
@@ -2179,7 +2218,14 @@ function(finalize_package)
 
   # Prepare public dependencies content
   set(PACKAGE_PUBLIC_DEPENDENCIES_CONTENT "")
+  set(_tip_package_public_content_required FALSE)
+  if(_tip_export_has_source_sets)
+    set(_tip_package_public_content_required TRUE)
+    string(APPEND PACKAGE_PUBLIC_DEPENDENCIES_CONTENT
+           "if(CMAKE_VERSION VERSION_LESS \"4.4\")\n  message(FATAL_ERROR \"Package '${ARG_EXPORT_NAME}' contains SOURCES file sets and requires CMake 4.4 or newer.\")\nendif()\n")
+  endif()
   if(PUBLIC_DEPENDENCIES)
+    set(_tip_package_public_content_required TRUE)
     foreach(dep ${PUBLIC_DEPENDENCIES})
       string(APPEND PACKAGE_PUBLIC_DEPENDENCIES_CONTENT "find_dependency(${dep})\n")
     endforeach()
@@ -2285,7 +2331,7 @@ function(finalize_package)
   endif()
 
   # Validate template contains required placeholders for provided parameters
-  _validate_config_template_placeholders("${CONFIG_TEMPLATE_TO_USE}" "${ARG_EXPORT_NAME}" "${INCLUDE_ON_FIND_PACKAGE}" "${PUBLIC_DEPENDENCIES}" "${_tip_find_package_components}")
+  _validate_config_template_placeholders("${CONFIG_TEMPLATE_TO_USE}" "${ARG_EXPORT_NAME}" "${INCLUDE_ON_FIND_PACKAGE}" "${_tip_package_public_content_required}" "${_tip_find_package_components}")
 
   # Generate correct config filename following CMake conventions Use <PackageName>Config.cmake format (exact case + "Config.cmake")
   set(CONFIG_FILENAME "${ARG_EXPORT_NAME}Config.cmake")

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -98,6 +98,7 @@ endif()
 #     SBOM_LICENSE <license>
 #     SBOM_DESCRIPTION <description>
 #     SBOM_HOMEPAGE_URL <url>
+#     SBOM_PACKAGE_URL <url>
 #     SBOM_FORMAT <format>
 #     DISABLE_RPATH)
 #
@@ -139,7 +140,7 @@ endif()
 #                                  SBOM version metadata defaults from explicit SBOM_VERSION, then explicit wrapper VERSION, then selected
 #                                  call-time project VERSION. Wrapper effective VERSION fallback only applies when SBOM_PROJECT was not explicit.
 #                                  CMAKE_EXPERIMENTAL_GENERATE_SBOM must be set to this CMake version's non-boolean activation value.
-#                                  SBOM_PACKAGE_URL is intentionally not exposed while CMake's experimental SBOM interface stabilizes.
+#                                  Exports sharing one SBOM_NAME are aggregated with CMake 4.4+ and must use identical metadata.
 #   DISABLE_RPATH                - Disable automatic RPATH configuration for Unix/Linux/macOS (default: OFF).
 #
 # Behavior:
@@ -339,6 +340,172 @@ function(_tip_validate_sbom_activation EXPORT_NAME)
   endif()
 endfunction()
 
+function(_tip_resolve_sbom_export_metadata EXPORT_NAME OUT_PREFIX)
+  set(_tip_export_property_prefix "_CMAKE_PACKAGE_EXPORT_${EXPORT_NAME}")
+  foreach(
+    _tip_property IN
+    ITEMS VERSION
+          VERSION_EXPLICIT
+          SBOM_NAME
+          SBOM_PROJECT
+          SBOM_DESTINATION
+          SBOM_VERSION
+          SBOM_VERSION_EXPLICIT
+          SBOM_INHERITED_VERSION
+          SBOM_LICENSE
+          SBOM_INHERITED_LICENSE
+          SBOM_DESCRIPTION
+          SBOM_INHERITED_DESCRIPTION
+          SBOM_HOMEPAGE_URL
+          SBOM_INHERITED_HOMEPAGE_URL
+          SBOM_PACKAGE_URL
+          SBOM_FORMAT
+          SBOM_METADATA_MODE
+          SBOM_EXPERIMENTAL_VALUE)
+    get_property(_tip_${_tip_property} GLOBAL PROPERTY "${_tip_export_property_prefix}_${_tip_property}")
+  endforeach()
+
+  if("${_tip_SBOM_NAME}" STREQUAL "")
+    set(_tip_SBOM_NAME "${EXPORT_NAME}")
+  endif()
+
+  set(_tip_effective_version "")
+  if(_tip_SBOM_VERSION_EXPLICIT)
+    set(_tip_effective_version "${_tip_SBOM_VERSION}")
+  elseif(_tip_VERSION_EXPLICIT)
+    set(_tip_effective_version "${_tip_VERSION}")
+  elseif(NOT "${_tip_SBOM_INHERITED_VERSION}" STREQUAL "")
+    set(_tip_effective_version "${_tip_SBOM_INHERITED_VERSION}")
+  elseif("${_tip_SBOM_PROJECT}" STREQUAL "")
+    set(_tip_effective_version "${_tip_VERSION}")
+  endif()
+
+  set(_tip_effective_license "${_tip_SBOM_LICENSE}")
+  if("${_tip_effective_license}" STREQUAL "")
+    set(_tip_effective_license "${_tip_SBOM_INHERITED_LICENSE}")
+  endif()
+
+  set(_tip_effective_description "${_tip_SBOM_DESCRIPTION}")
+  if("${_tip_effective_description}" STREQUAL "")
+    set(_tip_effective_description "${_tip_SBOM_INHERITED_DESCRIPTION}")
+  endif()
+
+  set(_tip_effective_homepage_url "${_tip_SBOM_HOMEPAGE_URL}")
+  if("${_tip_effective_homepage_url}" STREQUAL "")
+    set(_tip_effective_homepage_url "${_tip_SBOM_INHERITED_HOMEPAGE_URL}")
+  endif()
+
+  set(${OUT_PREFIX}_NAME
+      "${_tip_SBOM_NAME}"
+      PARENT_SCOPE)
+  set(${OUT_PREFIX}_DESTINATION
+      "${_tip_SBOM_DESTINATION}"
+      PARENT_SCOPE)
+  set(${OUT_PREFIX}_VERSION
+      "${_tip_effective_version}"
+      PARENT_SCOPE)
+  set(${OUT_PREFIX}_LICENSE
+      "${_tip_effective_license}"
+      PARENT_SCOPE)
+  set(${OUT_PREFIX}_DESCRIPTION
+      "${_tip_effective_description}"
+      PARENT_SCOPE)
+  set(${OUT_PREFIX}_HOMEPAGE_URL
+      "${_tip_effective_homepage_url}"
+      PARENT_SCOPE)
+  set(${OUT_PREFIX}_PACKAGE_URL
+      "${_tip_SBOM_PACKAGE_URL}"
+      PARENT_SCOPE)
+  set(${OUT_PREFIX}_FORMAT
+      "${_tip_SBOM_FORMAT}"
+      PARENT_SCOPE)
+  set(${OUT_PREFIX}_METADATA_MODE
+      "${_tip_SBOM_METADATA_MODE}"
+      PARENT_SCOPE)
+  set(${OUT_PREFIX}_EXPERIMENTAL_VALUE
+      "${_tip_SBOM_EXPERIMENTAL_VALUE}"
+      PARENT_SCOPE)
+endfunction()
+
+function(_tip_finalize_all_sboms)
+  get_property(_tip_sboms_finalized GLOBAL PROPERTY "_TIP_SBOMS_FINALIZED")
+  if(_tip_sboms_finalized)
+    return()
+  endif()
+
+  get_property(_tip_sbom_group_hashes GLOBAL PROPERTY "_TIP_SBOM_GROUP_HASHES")
+  foreach(_tip_sbom_group_hash IN LISTS _tip_sbom_group_hashes)
+    get_property(_tip_sbom_name GLOBAL PROPERTY "_TIP_SBOM_GROUP_${_tip_sbom_group_hash}_NAME")
+    get_property(_tip_sbom_exports GLOBAL PROPERTY "_TIP_SBOM_GROUP_${_tip_sbom_group_hash}_EXPORTS")
+    list(REMOVE_DUPLICATES _tip_sbom_exports)
+
+    foreach(_tip_sbom_export IN LISTS _tip_sbom_exports)
+      get_property(_tip_export_finalized GLOBAL PROPERTY "_CMAKE_PACKAGE_EXPORT_${_tip_sbom_export}_FINALIZED")
+      if(NOT _tip_export_finalized)
+        finalize_package(EXPORT_NAME "${_tip_sbom_export}")
+      endif()
+    endforeach()
+
+    list(GET _tip_sbom_exports 0 _tip_reference_export)
+    _tip_resolve_sbom_export_metadata("${_tip_reference_export}" _tip_reference)
+
+    foreach(_tip_sbom_export IN LISTS _tip_sbom_exports)
+      _tip_resolve_sbom_export_metadata("${_tip_sbom_export}" _tip_candidate)
+      foreach(
+        _tip_field IN
+        ITEMS NAME
+              DESTINATION
+              VERSION
+              LICENSE
+              DESCRIPTION
+              HOMEPAGE_URL
+              PACKAGE_URL
+              FORMAT
+              METADATA_MODE
+              EXPERIMENTAL_VALUE)
+        if(NOT "${_tip_candidate_${_tip_field}}" STREQUAL "${_tip_reference_${_tip_field}}")
+          string(REPLACE "_" " " _tip_field_description "${_tip_field}")
+          string(TOLOWER "${_tip_field_description}" _tip_field_description)
+          project_log(
+            FATAL_ERROR
+            "Conflicting SBOM ${_tip_field_description} for SBOM '${_tip_sbom_name}' across exports '${_tip_reference_export}' and '${_tip_sbom_export}': '${_tip_reference_${_tip_field}}' vs '${_tip_candidate_${_tip_field}}'."
+          )
+        endif()
+      endforeach()
+    endforeach()
+
+    set(CMAKE_EXPERIMENTAL_GENERATE_SBOM "${_tip_reference_EXPERIMENTAL_VALUE}")
+    _tip_validate_sbom_activation("${_tip_reference_export}")
+
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+      set(_tip_sbom_args SBOM "${_tip_sbom_name}" EXPORTS ${_tip_sbom_exports})
+    else()
+      list(GET _tip_sbom_exports 0 _tip_sbom_export)
+      set(_tip_sbom_args SBOM "${_tip_sbom_name}" EXPORT "${_tip_sbom_export}")
+    endif()
+    list(APPEND _tip_sbom_args NO_PROJECT_METADATA)
+
+    foreach(
+      _tip_field IN
+      ITEMS DESTINATION
+            VERSION
+            LICENSE
+            DESCRIPTION
+            HOMEPAGE_URL
+            PACKAGE_URL
+            FORMAT)
+      if(NOT "${_tip_reference_${_tip_field}}" STREQUAL "")
+        list(APPEND _tip_sbom_args "${_tip_field}" "${_tip_reference_${_tip_field}}")
+      endif()
+    endforeach()
+
+    install(${_tip_sbom_args})
+    project_log(STATUS "SBOM '${_tip_sbom_name}' is ready for exports: [${_tip_sbom_exports}]")
+  endforeach()
+
+  set_property(GLOBAL PROPERTY "_TIP_SBOMS_FINALIZED" TRUE)
+endfunction()
+
 function(_tip_component_dependency_property_name OUT_VAR EXPORT_PROPERTY_PREFIX COMPONENT_NAME)
   string(SHA256 _tip_component_hash "${COMPONENT_NAME}")
   set(${OUT_VAR}
@@ -461,9 +628,10 @@ endfunction()
 #     SBOM_LICENSE <license>
 #     SBOM_DESCRIPTION <description>
 #     SBOM_HOMEPAGE_URL <url>
+#     SBOM_PACKAGE_URL <url>
 #     SBOM_FORMAT <format>)
 #
-# SBOM requires CMAKE_EXPERIMENTAL_GENERATE_SBOM. SBOM_PACKAGE_URL is not exposed in v1.
+# SBOM requires CMAKE_EXPERIMENTAL_GENERATE_SBOM.
 #
 # See target_install_package() for parameter descriptions.
 # CONFIG_TEMPLATE resolution source of truth:
@@ -521,6 +689,7 @@ function(target_prepare_package TARGET_NAME)
       SBOM_LICENSE
       SBOM_DESCRIPTION
       SBOM_HOMEPAGE_URL
+      SBOM_PACKAGE_URL
       SBOM_FORMAT)
   set(multiValueArgs
       ADDITIONAL_FILES
@@ -783,6 +952,7 @@ function(target_prepare_package TARGET_NAME)
           ARG_SBOM_LICENSE
           ARG_SBOM_DESCRIPTION
           ARG_SBOM_HOMEPAGE_URL
+          ARG_SBOM_PACKAGE_URL
           ARG_SBOM_FORMAT)
     if(DEFINED ${_tip_sbom_arg} AND NOT "${${_tip_sbom_arg}}" STREQUAL "")
       set(_tip_sbom_specific_requested TRUE)
@@ -799,6 +969,15 @@ function(target_prepare_package TARGET_NAME)
   if(ARG_SBOM)
     _tip_validate_sbom_activation("${ARG_EXPORT_NAME}")
 
+    if(NOT "${ARG_SBOM_PACKAGE_URL}" STREQUAL "" AND CMAKE_VERSION VERSION_LESS "4.4")
+      project_log(FATAL_ERROR "SBOM_PACKAGE_URL requires CMake 4.4 or newer because CMake 4.3 does not accept PACKAGE_URL in install(SBOM).")
+    endif()
+
+    set(_tip_effective_sbom_name "${ARG_SBOM_NAME}")
+    if("${_tip_effective_sbom_name}" STREQUAL "")
+      set(_tip_effective_sbom_name "${ARG_EXPORT_NAME}")
+    endif()
+
     if(NOT "${ARG_SBOM_PROJECT}" STREQUAL "" AND ARG_SBOM_NO_PROJECT_METADATA)
       project_log(FATAL_ERROR "SBOM_PROJECT and SBOM_NO_PROJECT_METADATA cannot be used together.")
     endif()
@@ -812,11 +991,6 @@ function(target_prepare_package TARGET_NAME)
           project_log(FATAL_ERROR "SBOM_PROJECT '${ARG_SBOM_PROJECT}' is not visible from target '${TARGET_NAME}'.")
         endif()
       else()
-        set(_tip_effective_sbom_name "${ARG_SBOM_NAME}")
-        if("${_tip_effective_sbom_name}" STREQUAL "")
-          set(_tip_effective_sbom_name "${ARG_EXPORT_NAME}")
-        endif()
-
         if("${_tip_effective_sbom_name}" STREQUAL "${PROJECT_NAME}")
           set(_tip_sbom_metadata_project "${PROJECT_NAME}")
         endif()
@@ -1023,6 +1197,7 @@ function(target_prepare_package TARGET_NAME)
             SBOM_LICENSE
             SBOM_DESCRIPTION
             SBOM_HOMEPAGE_URL
+            SBOM_PACKAGE_URL
             SBOM_FORMAT)
       set(_tip_sbom_arg_var "ARG_${_tip_sbom_one_value}")
       if(DEFINED ${_tip_sbom_arg_var} AND NOT "${${_tip_sbom_arg_var}}" STREQUAL "")
@@ -1068,6 +1243,29 @@ function(target_prepare_package TARGET_NAME)
         _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "SBOM_INHERITED_HOMEPAGE_URL" "${${_tip_sbom_project_homepage_var}}" "SBOM inherited project homepage URL")
       endif()
     endif()
+
+    string(SHA256 _tip_sbom_group_hash "${_tip_effective_sbom_name}")
+    get_property(_tip_sbom_group_name GLOBAL PROPERTY "_TIP_SBOM_GROUP_${_tip_sbom_group_hash}_NAME")
+    if(NOT "${_tip_sbom_group_name}" STREQUAL "" AND NOT "${_tip_sbom_group_name}" STREQUAL "${_tip_effective_sbom_name}")
+      project_log(FATAL_ERROR "Internal SBOM name hash collision between '${_tip_sbom_group_name}' and '${_tip_effective_sbom_name}'.")
+    endif()
+    set_property(GLOBAL PROPERTY "_TIP_SBOM_GROUP_${_tip_sbom_group_hash}_NAME" "${_tip_effective_sbom_name}")
+
+    get_property(_tip_sbom_group_exports GLOBAL PROPERTY "_TIP_SBOM_GROUP_${_tip_sbom_group_hash}_EXPORTS")
+    if(CMAKE_VERSION VERSION_LESS "4.4"
+       AND _tip_sbom_group_exports
+       AND NOT ARG_EXPORT_NAME IN_LIST _tip_sbom_group_exports)
+      project_log(FATAL_ERROR
+                  "SBOM_NAME '${_tip_effective_sbom_name}' is already registered for export '${_tip_sbom_group_exports}'. Aggregating multiple export sets into one SBOM requires CMake 4.4 or newer.")
+    endif()
+    list(APPEND _tip_sbom_group_exports "${ARG_EXPORT_NAME}")
+    list(REMOVE_DUPLICATES _tip_sbom_group_exports)
+    set_property(GLOBAL PROPERTY "_TIP_SBOM_GROUP_${_tip_sbom_group_hash}_EXPORTS" "${_tip_sbom_group_exports}")
+
+    get_property(_tip_sbom_group_hashes GLOBAL PROPERTY "_TIP_SBOM_GROUP_HASHES")
+    list(APPEND _tip_sbom_group_hashes "${_tip_sbom_group_hash}")
+    list(REMOVE_DUPLICATES _tip_sbom_group_hashes)
+    set_property(GLOBAL PROPERTY "_TIP_SBOM_GROUP_HASHES" "${_tip_sbom_group_hashes}")
   endif()
 
   get_property(
@@ -1223,6 +1421,14 @@ function(target_prepare_package TARGET_NAME)
     # Schedule automatic finalization for this export at the end of configuration
     project_log(DEBUG "  Scheduling automatic finalization for export '${ARG_EXPORT_NAME}' at end of configuration")
     cmake_language(EVAL CODE "cmake_language(DEFER DIRECTORY \"${CMAKE_SOURCE_DIR}\" CALL _auto_finalize_single_export \"${ARG_EXPORT_NAME}\")")
+  endif()
+
+  if(ARG_SBOM)
+    get_property(_tip_sbom_finalization_scheduled GLOBAL PROPERTY "_TIP_SBOM_FINALIZATION_SCHEDULED")
+    if(NOT _tip_sbom_finalization_scheduled)
+      set_property(GLOBAL PROPERTY "_TIP_SBOM_FINALIZATION_SCHEDULED" TRUE)
+      cmake_language(EVAL CODE "cmake_language(DEFER DIRECTORY \"${CMAKE_SOURCE_DIR}\" CALL _tip_finalize_all_sboms)")
+    endif()
   endif()
 
   project_log(VERBOSE "Target '${TARGET_NAME}' configured successfully for export '${ARG_EXPORT_NAME}'")
@@ -1971,81 +2177,6 @@ function(finalize_package)
       DESTINATION ${CMAKE_CONFIG_DESTINATION}
       COMPONENT "${_tip_config_component}")
   endforeach()
-
-  if(SBOM_ENABLED)
-    set(CMAKE_EXPERIMENTAL_GENERATE_SBOM "${SBOM_EXPERIMENTAL_VALUE}")
-    _tip_validate_sbom_activation("${ARG_EXPORT_NAME}")
-
-    if(NOT "${SBOM_PROJECT}" STREQUAL "" AND SBOM_NO_PROJECT_METADATA)
-      project_log(FATAL_ERROR "SBOM_PROJECT and SBOM_NO_PROJECT_METADATA cannot be used together for export '${ARG_EXPORT_NAME}'.")
-    endif()
-
-    if("${SBOM_NAME}" STREQUAL "")
-      set(SBOM_NAME "${ARG_EXPORT_NAME}")
-    endif()
-
-    set(_tip_sbom_effective_version "")
-    if(SBOM_VERSION_EXPLICIT)
-      set(_tip_sbom_effective_version "${SBOM_VERSION}")
-    elseif(VERSION_EXPLICIT)
-      set(_tip_sbom_effective_version "${VERSION}")
-    elseif(NOT "${SBOM_INHERITED_VERSION}" STREQUAL "")
-      set(_tip_sbom_effective_version "${SBOM_INHERITED_VERSION}")
-    elseif("${SBOM_PROJECT}" STREQUAL "")
-      set(_tip_sbom_effective_version "${VERSION}")
-    endif()
-
-    set(_tip_sbom_effective_description "${SBOM_DESCRIPTION}")
-    if("${_tip_sbom_effective_description}" STREQUAL "")
-      set(_tip_sbom_effective_description "${SBOM_INHERITED_DESCRIPTION}")
-    endif()
-
-    set(_tip_sbom_effective_homepage_url "${SBOM_HOMEPAGE_URL}")
-    if("${_tip_sbom_effective_homepage_url}" STREQUAL "")
-      set(_tip_sbom_effective_homepage_url "${SBOM_INHERITED_HOMEPAGE_URL}")
-    endif()
-
-    set(_tip_sbom_effective_license "${SBOM_LICENSE}")
-    if("${_tip_sbom_effective_license}" STREQUAL "")
-      set(_tip_sbom_effective_license "${SBOM_INHERITED_LICENSE}")
-    endif()
-
-    # install(SBOM) is experimental, and CMake 4.4 replaced EXPORT with
-    # EXPORTS when it added support for aggregating multiple export sets.
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
-      set(_tip_sbom_args SBOM "${SBOM_NAME}" EXPORTS "${ARG_EXPORT_NAME}")
-    else()
-      set(_tip_sbom_args SBOM "${SBOM_NAME}" EXPORT "${ARG_EXPORT_NAME}")
-    endif()
-
-    if(SBOM_NO_PROJECT_METADATA
-       OR SBOM_INHERITED_PROJECT_METADATA
-       OR "${SBOM_METADATA_MODE}" STREQUAL "explicit")
-      list(APPEND _tip_sbom_args NO_PROJECT_METADATA)
-    endif()
-
-    if(NOT "${SBOM_DESTINATION}" STREQUAL "")
-      list(APPEND _tip_sbom_args DESTINATION "${SBOM_DESTINATION}")
-    endif()
-    if(NOT "${_tip_sbom_effective_version}" STREQUAL "")
-      list(APPEND _tip_sbom_args VERSION "${_tip_sbom_effective_version}")
-    endif()
-    if(NOT "${_tip_sbom_effective_license}" STREQUAL "")
-      list(APPEND _tip_sbom_args LICENSE "${_tip_sbom_effective_license}")
-    endif()
-    if(NOT "${_tip_sbom_effective_description}" STREQUAL "")
-      list(APPEND _tip_sbom_args DESCRIPTION "${_tip_sbom_effective_description}")
-    endif()
-    if(NOT "${_tip_sbom_effective_homepage_url}" STREQUAL "")
-      list(APPEND _tip_sbom_args HOMEPAGE_URL "${_tip_sbom_effective_homepage_url}")
-    endif()
-    if(NOT "${SBOM_FORMAT}" STREQUAL "")
-      list(APPEND _tip_sbom_args FORMAT "${SBOM_FORMAT}")
-    endif()
-
-    install(${_tip_sbom_args})
-    project_log(STATUS "SBOM '${SBOM_NAME}' is ready for export '${ARG_EXPORT_NAME}'")
-  endif()
 
   if(CPS_ENABLED)
     if(CMAKE_VERSION VERSION_LESS "4.3")

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.0.8)
+  list_file_include_guard(VERSION 7.1.0)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 
@@ -102,7 +102,7 @@ endif()
 #     SBOM_FORMAT <format>
 #     DISABLE_RPATH)
 #
-#   SBOM requires CMAKE_EXPERIMENTAL_GENERATE_SBOM. SBOM_PACKAGE_URL is not exposed in v1.
+#   SBOM requires CMAKE_EXPERIMENTAL_GENERATE_SBOM.
 #
 # Parameters:
 #   TARGET_NAME                  - Name of the target to install.

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -52,6 +52,7 @@ endif()
 #     ALIAS_NAME <alias_name>
 #     VERSION <version>
 #     COMPATIBILITY <compatibility>
+#     ARCH_INDEPENDENT
 #     EXPORT_NAME <export_name>
 #     CONFIG_TEMPLATE <template_path>
 #     INCLUDE_DESTINATION <include_dest>
@@ -107,6 +108,7 @@ endif()
 #   ALIAS_NAME                   - Custom alias name for the exported target (default: `${TARGET_NAME}`).
 #   VERSION                      - Version of the package (default: `${PROJECT_VERSION}`).
 #   COMPATIBILITY                - Version compatibility mode (default: "SameMajorVersion").
+#   ARCH_INDEPENDENT             - Disable architecture suitability checks in the generated package version file.
 #   EXPORT_NAME                  - Name of the CMake export file (default: `${TARGET_NAME}`).
 #   CONFIG_TEMPLATE              - Optional path to a CMake config template.
 #                                  Source of truth for resolution order:
@@ -268,7 +270,9 @@ function(_tip_derive_cps_compat_version OUT_VAR VERSION COMPATIBILITY VERSION_SC
     return()
   endif()
 
-  if("${COMPATIBILITY}" STREQUAL "ExactVersion")
+  if("${COMPATIBILITY}" STREQUAL "ExactVersion"
+     OR "${COMPATIBILITY}" STREQUAL "SamePatchVersion"
+     OR "${COMPATIBILITY}" STREQUAL "SameFullVersion")
     set(${OUT_VAR}
         ""
         PARENT_SCOPE)
@@ -288,6 +292,12 @@ function(_tip_derive_cps_compat_version OUT_VAR VERSION COMPATIBILITY VERSION_SC
       set(_tip_compat_version "${_tip_major}.0.0")
     elseif("${COMPATIBILITY}" STREQUAL "SameMinorVersion")
       set(_tip_compat_version "${_tip_major}.${_tip_minor}.0")
+    elseif("${COMPATIBILITY}" STREQUAL "SemanticVersion")
+      if(_tip_major EQUAL 0)
+        set(_tip_compat_version "0.${_tip_minor}.0")
+      else()
+        set(_tip_compat_version "${_tip_major}.0.0")
+      endif()
     endif()
   endif()
 
@@ -403,6 +413,7 @@ endfunction()
 #     ALIAS_NAME <alias_name>
 #     VERSION <version>
 #     COMPATIBILITY <compatibility>
+#     ARCH_INDEPENDENT
 #     EXPORT_NAME <export_name>
 #     CONFIG_TEMPLATE <template_path>
 #     INCLUDE_DESTINATION <include_dest>
@@ -464,6 +475,7 @@ function(target_prepare_package TARGET_NAME)
   # Parse function arguments
   set(options
       DISABLE_RPATH
+      ARCH_INDEPENDENT
       CPS
       CPS_NO_PROJECT_METADATA
       CPS_LOWER_CASE_FILE
@@ -662,9 +674,22 @@ function(target_prepare_package TARGET_NAME)
     "Additional files destination")
 
   # Validate compatibility parameter
-  set(VALID_COMPATIBILITY "AnyNewerVersion;SameMajorVersion;SameMinorVersion;ExactVersion")
-  if(NOT ARG_COMPATIBILITY IN_LIST VALID_COMPATIBILITY)
-    project_log(FATAL_ERROR "Invalid COMPATIBILITY '${ARG_COMPATIBILITY}'. Must be one of: ${VALID_COMPATIBILITY}")
+  set(_tip_legacy_compatibility AnyNewerVersion SameMajorVersion SameMinorVersion ExactVersion)
+  set(_tip_cmake_44_compatibility SamePatchVersion SameFullVersion SemanticVersion)
+  set(_tip_valid_compatibility ${_tip_legacy_compatibility})
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+    list(APPEND _tip_valid_compatibility ${_tip_cmake_44_compatibility})
+  endif()
+
+  if(NOT ARG_COMPATIBILITY IN_LIST _tip_valid_compatibility)
+    if(ARG_COMPATIBILITY IN_LIST _tip_cmake_44_compatibility)
+      project_log(FATAL_ERROR "COMPATIBILITY '${ARG_COMPATIBILITY}' requires CMake 4.4 or newer.")
+    endif()
+    project_log(FATAL_ERROR "Invalid COMPATIBILITY '${ARG_COMPATIBILITY}'. Supported values: ${_tip_valid_compatibility}")
+  endif()
+
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4" AND ARG_COMPATIBILITY STREQUAL "ExactVersion")
+    message(DEPRECATION "COMPATIBILITY ExactVersion is deprecated by CMake 4.4. Use SamePatchVersion to ignore tweak, or SameFullVersion to require every version component to match.")
   endif()
 
   set(_tip_cps_specific_requested FALSE)
@@ -913,6 +938,7 @@ function(target_prepare_package TARGET_NAME)
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "NAMESPACE" "${ARG_NAMESPACE}" "namespace")
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "VERSION" "${ARG_VERSION}" "version")
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "COMPATIBILITY" "${ARG_COMPATIBILITY}" "compatibility")
+  _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "ARCH_INDEPENDENT" "${ARG_ARCH_INDEPENDENT}" "architecture independence")
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "CONFIG_TEMPLATE" "${ARG_CONFIG_TEMPLATE}" "config template")
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "INCLUDE_DESTINATION" "${ARG_INCLUDE_DESTINATION}" "include destination")
   _tip_store_export_property("${EXPORT_PROPERTY_PREFIX}" "${ARG_EXPORT_NAME}" "MODULE_DESTINATION" "${ARG_MODULE_DESTINATION}" "module destination")
@@ -1438,6 +1464,7 @@ function(finalize_package)
   get_property(NAMESPACE GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_NAMESPACE")
   get_property(VERSION GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_VERSION")
   get_property(COMPATIBILITY GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_COMPATIBILITY")
+  get_property(ARCH_INDEPENDENT GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_ARCH_INDEPENDENT")
   get_property(CONFIG_TEMPLATE GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_CONFIG_TEMPLATE")
   get_property(INCLUDE_DESTINATION GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_INCLUDE_DESTINATION")
   get_property(MODULE_DESTINATION GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_MODULE_DESTINATION")
@@ -2063,6 +2090,12 @@ function(finalize_package)
         set(_tip_cps_effective_compat_version "${CPS_COMPAT_VERSION}")
         if("${_tip_cps_effective_compat_version}" STREQUAL "")
           _tip_derive_cps_compat_version(_tip_cps_effective_compat_version "${_tip_cps_effective_version}" "${COMPATIBILITY}" "${CPS_VERSION_SCHEMA}")
+          if(COMPATIBILITY STREQUAL "SamePatchVersion" OR COMPATIBILITY STREQUAL "ExactVersion")
+            project_log(
+              WARNING
+              "CPS cannot represent COMPATIBILITY '${COMPATIBILITY}' exactly for export '${ARG_EXPORT_NAME}'. Omitting COMPAT_VERSION makes CPS require the package version. Set CPS_COMPAT_VERSION explicitly to override this stricter behavior."
+            )
+          endif()
         endif()
         if(NOT "${_tip_cps_effective_compat_version}" STREQUAL "")
           list(APPEND _tip_cps_args COMPAT_VERSION "${_tip_cps_effective_compat_version}")
@@ -2134,10 +2167,11 @@ function(finalize_package)
   set(LEGACY_VERSION_FILENAME "${ARG_EXPORT_NAME}-config-version.cmake")
   set(LEGACY_VERSION_FILE_PATH "${CURRENT_BINARY_DIR}/${LEGACY_VERSION_FILENAME}")
 
-  write_basic_package_version_file(
-    "${VERSION_FILE_PATH}"
-    VERSION ${VERSION}
-    COMPATIBILITY ${COMPATIBILITY})
+  set(_tip_version_file_args "${VERSION_FILE_PATH}" VERSION ${VERSION} COMPATIBILITY ${COMPATIBILITY})
+  if(ARCH_INDEPENDENT)
+    list(APPEND _tip_version_file_args ARCH_INDEPENDENT)
+  endif()
+  write_basic_package_version_file(${_tip_version_file_args})
 
   if(NOT VERSION_FILENAME STREQUAL LEGACY_VERSION_FILENAME)
     configure_file("${VERSION_FILE_PATH}" "${LEGACY_VERSION_FILE_PATH}" COPYONLY)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -277,6 +277,20 @@ if(target_install_package_BUILD_PROOF_TESTS)
   add_test(NAME proof_versioned_find_package COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_versioned_find_package_test.cmake")
   set_tests_properties(proof_versioned_find_package PROPERTIES LABELS "proof;review")
 
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+    add_test(NAME proof_cmake_44_version_compatibility COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_cmake_44_version_compatibility_test.cmake")
+    set_tests_properties(proof_cmake_44_version_compatibility PROPERTIES LABELS "proof;review;cmake-4.4")
+
+    if(target_install_package_PROOF_OLD_CMAKE_COMMAND)
+      add_test(NAME proof_cmake_44_version_old_cmake_guard COMMAND "${target_install_package_PROOF_OLD_CMAKE_COMMAND}" ${_tip_proof_common_args} -P
+                                                                   "${_tip_proof_script_dir}/proof_cmake_44_version_old_cmake_guard_test.cmake")
+      set_tests_properties(proof_cmake_44_version_old_cmake_guard PROPERTIES LABELS "proof;review;cmake-4.4")
+    endif()
+  else()
+    add_test(NAME proof_cmake_44_version_old_cmake_guard COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_cmake_44_version_old_cmake_guard_test.cmake")
+    set_tests_properties(proof_cmake_44_version_old_cmake_guard PROPERTIES LABELS "proof;review;cmake-4.4")
+  endif()
+
   add_test(NAME proof_component_find_package COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_component_find_package_test.cmake")
   set_tests_properties(proof_component_find_package PROPERTIES LABELS "proof;review")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -286,9 +286,25 @@ if(target_install_package_BUILD_PROOF_TESTS)
                                                                    "${_tip_proof_script_dir}/proof_cmake_44_version_old_cmake_guard_test.cmake")
       set_tests_properties(proof_cmake_44_version_old_cmake_guard PROPERTIES LABELS "proof;review;cmake-4.4")
     endif()
+
+    add_test(NAME proof_source_file_sets COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} "-DTIP_OLD_CMAKE_COMMAND=${target_install_package_PROOF_OLD_CMAKE_COMMAND}" -P
+                                                 "${_tip_proof_script_dir}/proof_source_file_sets_test.cmake")
+    set_tests_properties(proof_source_file_sets PROPERTIES LABELS "proof;review;cmake-4.4;sources")
+
+    add_test(NAME proof_source_file_sets_failures COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_source_file_sets_failures_test.cmake")
+    set_tests_properties(proof_source_file_sets_failures PROPERTIES LABELS "proof;review;cmake-4.4;sources")
   else()
     add_test(NAME proof_cmake_44_version_old_cmake_guard COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_cmake_44_version_old_cmake_guard_test.cmake")
     set_tests_properties(proof_cmake_44_version_old_cmake_guard PROPERTIES LABELS "proof;review;cmake-4.4")
+  endif()
+
+  if(CMAKE_VERSION VERSION_LESS "4.4")
+    add_test(NAME proof_source_file_sets_old_cmake_guard COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_source_file_sets_old_cmake_guard_test.cmake")
+    set_tests_properties(proof_source_file_sets_old_cmake_guard PROPERTIES LABELS "proof;review;cmake-4.4;sources")
+  elseif(target_install_package_PROOF_OLD_CMAKE_COMMAND)
+    add_test(NAME proof_source_file_sets_old_cmake_guard COMMAND "${target_install_package_PROOF_OLD_CMAKE_COMMAND}" ${_tip_proof_common_args} -P
+                                                                 "${_tip_proof_script_dir}/proof_source_file_sets_old_cmake_guard_test.cmake")
+    set_tests_properties(proof_source_file_sets_old_cmake_guard PROPERTIES LABELS "proof;review;cmake-4.4;sources")
   endif()
 
   add_test(NAME proof_component_find_package COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_component_find_package_test.cmake")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -313,6 +313,9 @@ if(target_install_package_BUILD_PROOF_TESTS)
   add_test(NAME proof_cpack_component_metadata COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_cpack_component_metadata_test.cmake")
   set_tests_properties(proof_cpack_component_metadata PROPERTIES LABELS "proof;review;cpack")
 
+  add_test(NAME proof_cpack_checksums COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_cpack_checksums_test.cmake")
+  set_tests_properties(proof_cpack_checksums PROPERTIES LABELS "proof;review;cpack;checksums")
+
   add_test(NAME proof_cpack_native_component_dependencies COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_cpack_native_component_dependencies_test.cmake")
   set_tests_properties(proof_cpack_native_component_dependencies PROPERTIES LABELS "proof;review;cpack")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -386,6 +386,12 @@ if(target_install_package_BUILD_PROOF_TESTS)
       add_test(NAME proof_sbom_metadata_conflict COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} "-DTIP_SBOM_EXPERIMENTAL_VALUE=${target_install_package_PROOF_SBOM_EXPERIMENTAL_VALUE}" -P
                                                          "${_tip_proof_script_dir}/proof_sbom_metadata_conflict_test.cmake")
       set_tests_properties(proof_sbom_metadata_conflict PROPERTIES LABELS "proof;sbom")
+
+      if(CMAKE_VERSION VERSION_LESS "4.4")
+        add_test(NAME proof_sbom_multi_export_guard COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} "-DTIP_SBOM_EXPERIMENTAL_VALUE=${target_install_package_PROOF_SBOM_EXPERIMENTAL_VALUE}" -P
+                                                            "${_tip_proof_script_dir}/proof_sbom_multi_export_guard_test.cmake")
+        set_tests_properties(proof_sbom_multi_export_guard PROPERTIES LABELS "proof;sbom;cmake-4.3")
+      endif()
     endif()
 
     add_test(NAME proof_sbom_missing_gate COMMAND ${CMAKE_COMMAND} ${_tip_proof_common_args} -P "${_tip_proof_script_dir}/proof_sbom_missing_gate_test.cmake")

--- a/tests/cmake/proof_cmake_44_version_compatibility_test.cmake
+++ b/tests/cmake/proof_cmake_44_version_compatibility_test.cmake
@@ -1,0 +1,121 @@
+cmake_minimum_required(VERSION 4.4)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/cmake-44-version-compatibility")
+set(_tip_fixture_source_dir "${_tip_case_root}/fixture-src")
+set(_tip_fixture_build_dir "${_tip_case_root}/fixture-build")
+set(_tip_install_prefix "${_tip_case_root}/fixture-install")
+
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_fixture_source_dir}")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+
+file(
+  WRITE "${_tip_fixture_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 4.4)\n"
+  "project(proof_cmake_44_versions VERSION 1.2.3.4 LANGUAGES CXX)\n"
+  "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+  "function(add_version_package name version compatibility)\n"
+  "  add_library(\${name} INTERFACE)\n"
+  "  target_install_package(\${name} EXPORT_NAME \${name}_pkg VERSION \${version} COMPATIBILITY \${compatibility} \${ARGN})\n"
+  "endfunction()\n"
+  "function(assert_cps_floor compatibility version expected)\n"
+  "  _tip_derive_cps_compat_version(actual \"\${version}\" \"\${compatibility}\" simple)\n"
+  "  if(NOT \"\${actual}\" STREQUAL \"\${expected}\")\n"
+  "    message(FATAL_ERROR \"CPS floor for \${compatibility} \${version}: expected '\${expected}', got '\${actual}'\")\n"
+  "  endif()\n"
+  "endfunction()\n"
+  "assert_cps_floor(SemanticVersion 1.2.3 1.0.0)\n"
+  "assert_cps_floor(SemanticVersion 0.2.3 0.2.0)\n"
+  "assert_cps_floor(SameFullVersion 1.2.3 \"\")\n"
+  "assert_cps_floor(SamePatchVersion 1.2.3.4 \"\")\n"
+  "add_version_package(same_patch 1.2.3.4 SamePatchVersion)\n"
+  "add_version_package(same_full 1.2.3 SameFullVersion)\n"
+  "add_version_package(semantic_stable 1.2.3 SemanticVersion)\n"
+  "add_version_package(semantic_zero 0.2.3 SemanticVersion)\n"
+  "add_version_package(arch_independent 1.2.3 SameMajorVersion ARCH_INDEPENDENT)\n"
+  "add_version_package(arch_dependent 1.2.3 SameMajorVersion)\n"
+  "add_version_package(exact_deprecated 1.2.3 ExactVersion)\n")
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" -S "${_tip_fixture_source_dir}" -B "${_tip_fixture_build_dir}" ${_tip_toolchain_args}
+  RESULT_VARIABLE _tip_configure_result
+  OUTPUT_VARIABLE _tip_configure_stdout
+  ERROR_VARIABLE _tip_configure_stderr)
+if(NOT _tip_configure_result EQUAL 0)
+  message(STATUS "[proof][stdout]\n${_tip_configure_stdout}")
+  message(STATUS "[proof][stderr]\n${_tip_configure_stderr}")
+  _tip_proof_fail("CMake 4.4 version fixture configure failed")
+endif()
+set(_tip_configure_output "${_tip_configure_stdout}\n${_tip_configure_stderr}")
+string(FIND "${_tip_configure_output}" "COMPATIBILITY ExactVersion is deprecated by CMake 4.4" _tip_deprecation_index)
+if(_tip_deprecation_index EQUAL -1)
+  _tip_proof_fail("Expected ExactVersion deprecation message during configure")
+endif()
+
+_tip_proof_run_step(
+  NAME
+  "fixture-install"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --install
+  "${_tip_fixture_build_dir}"
+  --prefix
+  "${_tip_install_prefix}")
+
+function(_tip_check_find name package requirement expect_success)
+  set(_tip_source_dir "${_tip_case_root}/consumer-${name}-src")
+  set(_tip_build_dir "${_tip_case_root}/consumer-${name}-build")
+  file(MAKE_DIRECTORY "${_tip_source_dir}")
+  file(WRITE "${_tip_source_dir}/CMakeLists.txt" "cmake_minimum_required(VERSION 4.4)\n" "project(consumer_${name} LANGUAGES NONE)\n"
+                                                 "find_package(${package} ${requirement} CONFIG REQUIRED PATHS \"${_tip_install_prefix}\" NO_DEFAULT_PATH)\n")
+
+  set(_tip_command "${CMAKE_COMMAND}" -S "${_tip_source_dir}" -B "${_tip_build_dir}")
+  if(expect_success)
+    _tip_proof_run_step(NAME "find-${name}" COMMAND ${_tip_command})
+  else()
+    _tip_proof_expect_failure(NAME "find-${name}" COMMAND ${_tip_command})
+  endif()
+endfunction()
+
+_tip_check_find(same-patch-tweak same_patch_pkg 1.2.3.5 TRUE)
+_tip_check_find(same-patch-change same_patch_pkg 1.2.4 FALSE)
+_tip_check_find(same-full-count same_full_pkg 1.2.3.0 FALSE)
+_tip_check_find(same-full-exact same_full_pkg 1.2.3 TRUE)
+_tip_check_find(semantic-stable semantic_stable_pkg 1.0 TRUE)
+_tip_check_find(semantic-stable-major semantic_stable_pkg 2.0 FALSE)
+_tip_check_find(semantic-zero semantic_zero_pkg 0.2.0 TRUE)
+_tip_check_find(semantic-zero-minor semantic_zero_pkg 0.1 FALSE)
+_tip_check_find(semantic-range semantic_stable_pkg "1.0...<2.0" TRUE)
+
+function(_tip_check_architecture package expect_unsuitable)
+  set(PACKAGE_FIND_VERSION 1.2.3)
+  set(PACKAGE_FIND_VERSION_MAJOR 1)
+  set(PACKAGE_FIND_VERSION_MINOR 2)
+  set(PACKAGE_FIND_VERSION_PATCH 3)
+  set(PACKAGE_FIND_VERSION_TWEAK 0)
+  set(PACKAGE_FIND_VERSION_COUNT 3)
+  set(CMAKE_SIZEOF_VOID_P 4)
+  unset(PACKAGE_VERSION_UNSUITABLE)
+  include("${_tip_install_prefix}/share/cmake/${package}/${package}ConfigVersion.cmake")
+  if(expect_unsuitable AND NOT PACKAGE_VERSION_UNSUITABLE)
+    _tip_proof_fail("Expected ${package} to reject the simulated architecture mismatch")
+  elseif(NOT expect_unsuitable AND PACKAGE_VERSION_UNSUITABLE)
+    _tip_proof_fail("Expected ${package} to ignore the simulated architecture mismatch")
+  endif()
+endfunction()
+
+_tip_check_architecture(arch_dependent_pkg TRUE)
+_tip_check_architecture(arch_independent_pkg FALSE)
+
+message(STATUS "[proof] CMake 4.4 version compatibility proof passed.")

--- a/tests/cmake/proof_cmake_44_version_old_cmake_guard_test.cmake
+++ b/tests/cmake/proof_cmake_44_version_old_cmake_guard_test.cmake
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.25)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+  _tip_proof_fail("proof_cmake_44_version_old_cmake_guard requires CMake older than 4.4")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/cmake-44-version-old-cmake-guard")
+set(_tip_source_dir "${_tip_case_root}/src")
+set(_tip_build_dir "${_tip_case_root}/build")
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_source_dir}")
+
+file(WRITE "${_tip_source_dir}/CMakeLists.txt"
+     "cmake_minimum_required(VERSION 3.25)\n" "project(proof_cmake_44_version_guard LANGUAGES NONE)\n" "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+     "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n" "add_library(guarded INTERFACE)\n" "target_install_package(guarded VERSION 1.2.3 COMPATIBILITY SamePatchVersion)\n")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+_tip_proof_expect_failure(
+  NAME
+  "cmake-44-version-mode-on-old-cmake"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  -S
+  "${_tip_source_dir}"
+  -B
+  "${_tip_build_dir}"
+  ${_tip_toolchain_args}
+  EXPECT_CONTAINS
+  "'SamePatchVersion' requires CMake 4.4 or newer")
+
+message(STATUS "[proof] CMake 4.4 version old-CMake guard proof passed.")

--- a/tests/cmake/proof_cpack_checksums_test.cmake
+++ b/tests/cmake/proof_cpack_checksums_test.cmake
@@ -1,0 +1,112 @@
+cmake_minimum_required(VERSION 3.25)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+if(NOT CMAKE_CPACK_COMMAND)
+  _tip_proof_fail("CMAKE_CPACK_COMMAND is required")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/cpack-checksums")
+set(_tip_source_dir "${_tip_case_root}/src")
+set(_tip_build_dir "${_tip_case_root}/build")
+set(_tip_package_dir "${_tip_case_root}/packages")
+set(_tip_algorithms
+    MD5
+    SHA1
+    SHA224
+    SHA256
+    SHA384
+    SHA512
+    SHA3_224
+    SHA3_256
+    SHA3_384
+    SHA3_512)
+
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_source_dir}" "${_tip_package_dir}")
+file(WRITE "${_tip_source_dir}/payload.txt" "checksum proof\n")
+file(
+  WRITE "${_tip_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 3.25)\n" "project(proof_cpack_checksums VERSION 1.0.0 LANGUAGES NONE)\n" "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n" "install(FILES payload.txt DESTINATION share/proof)\n"
+  "export_cpack(PACKAGE_NAME ProofChecksums PACKAGE_VERSION 1.0.0 GENERATORS TGZ NO_DEFAULT_GENERATORS CHECKSUMS md5 sha1 sha224 sha256 sha384 sha512 sha3_224 sha3_256 sha3_384 sha3_512)\n")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+_tip_proof_run_step(
+  NAME
+  "configure"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  -S
+  "${_tip_source_dir}"
+  -B
+  "${_tip_build_dir}"
+  ${_tip_toolchain_args})
+
+set(_tip_cpack_config "${_tip_build_dir}/CPackConfig.cmake")
+_tip_proof_assert_exists("${_tip_cpack_config}")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.2")
+  _tip_proof_assert_file_contains("${_tip_cpack_config}" "set(CPACK_PACKAGE_CHECKSUM \"${_tip_algorithms}\")")
+  _tip_proof_assert_not_exists("${_tip_build_dir}/sign_packages.cmake")
+else()
+  _tip_proof_assert_file_not_contains("${_tip_cpack_config}" "CPACK_PACKAGE_CHECKSUM")
+  _tip_proof_assert_file_contains("${_tip_build_dir}/sign_packages.cmake" "set(CHECKSUMS \"${_tip_algorithms}\")")
+endif()
+
+_tip_proof_run_step(
+  NAME
+  "package"
+  COMMAND
+  "${CMAKE_CPACK_COMMAND}"
+  -G
+  TGZ
+  --config
+  "${_tip_cpack_config}"
+  -B
+  "${_tip_package_dir}")
+file(GLOB _tip_packages "${_tip_package_dir}/*.tar.gz")
+list(LENGTH _tip_packages _tip_package_count)
+if(_tip_package_count EQUAL 0)
+  _tip_proof_fail("Expected at least one TGZ package")
+endif()
+
+foreach(_tip_package IN LISTS _tip_packages)
+  foreach(_tip_algorithm IN LISTS _tip_algorithms)
+    string(TOLOWER "${_tip_algorithm}" _tip_extension)
+    set(_tip_checksum_file "${_tip_package}.${_tip_extension}")
+    _tip_proof_assert_exists("${_tip_checksum_file}")
+    file(${_tip_algorithm} "${_tip_package}" _tip_expected_hash)
+    _tip_proof_assert_file_contains("${_tip_checksum_file}" "${_tip_expected_hash}")
+  endforeach()
+endforeach()
+
+function(_tip_write_invalid_fixture name invocation expected)
+  set(_tip_invalid_source_dir "${_tip_case_root}/${name}-src")
+  set(_tip_invalid_build_dir "${_tip_case_root}/${name}-build")
+  file(MAKE_DIRECTORY "${_tip_invalid_source_dir}")
+  file(WRITE "${_tip_invalid_source_dir}/CMakeLists.txt" "cmake_minimum_required(VERSION 3.25)\n" "project(proof_${name} VERSION 1.0.0 LANGUAGES NONE)\n"
+                                                         "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n" "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n" "${invocation}\n")
+  _tip_proof_expect_failure(
+    NAME
+    "${name}"
+    COMMAND
+    "${CMAKE_COMMAND}"
+    -S
+    "${_tip_invalid_source_dir}"
+    -B
+    "${_tip_invalid_build_dir}"
+    ${_tip_toolchain_args}
+    EXPECT_CONTAINS
+    "${expected}")
+endfunction()
+
+_tip_write_invalid_fixture("checksum-conflict" "export_cpack(GENERATORS TGZ CHECKSUMS SHA256 GENERATE_CHECKSUMS ON)" "cannot be used together")
+_tip_write_invalid_fixture("checksum-invalid" "export_cpack(GENERATORS TGZ CHECKSUMS BLAKE3)" "'BLAKE3'.  Supported values")
+
+message(STATUS "[proof] CPack checksum proof passed.")

--- a/tests/cmake/proof_gpg_signing_methods_test.cmake
+++ b/tests/cmake/proof_gpg_signing_methods_test.cmake
@@ -61,6 +61,24 @@ file(MAKE_DIRECTORY "${_tip_checksums_only_package_dir}")
 
 _tip_proof_append_toolchain_args(_tip_toolchain_args)
 
+function(_tip_assert_checksum_configuration build_dir)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.2")
+    _tip_proof_assert_file_contains("${build_dir}/CPackConfig.cmake" "set(CPACK_PACKAGE_CHECKSUM \"SHA256;SHA512\")")
+  else()
+    _tip_proof_assert_file_contains("${build_dir}/sign_packages.cmake" "set(CHECKSUMS \"SHA256;SHA512\")")
+  endif()
+endfunction()
+
+function(_tip_assert_manual_checksum_result package_file)
+  if(CMAKE_VERSION VERSION_LESS "4.2")
+    _tip_proof_assert_exists("${package_file}.sha256")
+    _tip_proof_assert_exists("${package_file}.sha512")
+  else()
+    _tip_proof_assert_not_exists("${package_file}.sha256")
+    _tip_proof_assert_not_exists("${package_file}.sha512")
+  endif()
+endfunction()
+
 file(
   WRITE "${_tip_fake_bin_dir}/gpg"
   "#!/bin/sh\n"
@@ -112,6 +130,7 @@ set(_tip_configure_command "${CMAKE_COMMAND}" -E env "PATH=${_tip_fake_bin_dir}:
                            "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_PROGRAM_PATH=${_tip_fake_bin_dir}" ${_tip_toolchain_args})
 
 _tip_proof_run_step(NAME "configure" COMMAND ${_tip_configure_command})
+_tip_assert_checksum_configuration("${_tip_build_dir}")
 
 set(_tip_tgz_package "${_tip_tgz_package_dir}/proof.tar.gz")
 file(WRITE "${_tip_tgz_package}" "tgz\n")
@@ -126,8 +145,7 @@ _tip_proof_run_step(
   "${_tip_build_dir}/sign_packages.cmake")
 
 _tip_proof_assert_exists("${_tip_tgz_package_dir}/proof.tar.gz.sig")
-_tip_proof_assert_exists("${_tip_tgz_package_dir}/proof.tar.gz.sha256")
-_tip_proof_assert_exists("${_tip_tgz_package_dir}/proof.tar.gz.sha512")
+_tip_assert_manual_checksum_result("${_tip_tgz_package}")
 _tip_proof_assert_file_contains("${_tip_case_root}/gpg.log" "--passphrase=")
 _tip_proof_assert_not_exists("${_tip_case_root}/rpmsign.log")
 
@@ -144,8 +162,7 @@ _tip_proof_run_step(
   "${_tip_build_dir}/sign_packages.cmake")
 
 _tip_proof_assert_exists("${_tip_rpm_package_dir}/proof.rpm.sig")
-_tip_proof_assert_exists("${_tip_rpm_package_dir}/proof.rpm.sha256")
-_tip_proof_assert_exists("${_tip_rpm_package_dir}/proof.rpm.sha512")
+_tip_assert_manual_checksum_result("${_tip_rpm_package}")
 _tip_proof_assert_file_contains("${_tip_case_root}/rpmsign.log" "--addsign")
 _tip_proof_assert_file_contains("${_tip_case_root}/rpmsign.log" "${_tip_rpm_package}")
 
@@ -159,9 +176,8 @@ file(
   "target_install_package(proof_embedded_lib)\n"
   "export_cpack(PACKAGE_NAME ProofSigningEmbedded GENERATORS RPM SIGNING_METHOD embedded GENERATE_CHECKSUMS OFF)\n")
 
-set(_tip_embedded_configure_command "${CMAKE_COMMAND}" -E env "PATH=${_tip_fake_bin_dir}:$ENV{PATH}" "GPG_SIGNING_KEY=proof@example.invalid" "${CMAKE_COMMAND}" -S
-                                    "${_tip_embedded_source_dir}" -B "${_tip_embedded_build_dir}" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_PROGRAM_PATH=${_tip_fake_bin_dir}"
-                                    ${_tip_toolchain_args})
+set(_tip_embedded_configure_command "${CMAKE_COMMAND}" -E env "PATH=${_tip_fake_bin_dir}:$ENV{PATH}" "GPG_SIGNING_KEY=proof@example.invalid" "${CMAKE_COMMAND}" -S "${_tip_embedded_source_dir}" -B
+                                    "${_tip_embedded_build_dir}" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_PROGRAM_PATH=${_tip_fake_bin_dir}" ${_tip_toolchain_args})
 
 _tip_proof_run_step(NAME "embedded-configure" COMMAND ${_tip_embedded_configure_command})
 
@@ -193,7 +209,7 @@ file(
   "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
   "add_library(proof_both_no_rpm_lib INTERFACE)\n"
   "target_install_package(proof_both_no_rpm_lib)\n"
-  "export_cpack(PACKAGE_NAME ProofSigningBothNoRpm GENERATORS TGZ SIGNING_METHOD both GENERATE_CHECKSUMS ON)\n")
+  "export_cpack(PACKAGE_NAME ProofSigningBothNoRpm GENERATORS TGZ SIGNING_METHOD both)\n")
 
 set(_tip_both_no_rpm_configure_command
     "${CMAKE_COMMAND}" -E env "PATH=${_tip_fake_gpg_only_bin_dir}:$ENV{PATH}" "GPG_SIGNING_KEY=proof@example.invalid" "${CMAKE_COMMAND}" -S "${_tip_both_no_rpm_source_dir}" -B
@@ -201,6 +217,7 @@ set(_tip_both_no_rpm_configure_command
     "-DCMAKE_PROGRAM_PATH=${_tip_fake_gpg_only_bin_dir}" ${_tip_toolchain_args})
 
 _tip_proof_run_step(NAME "both-no-rpm-configure-without-rpmsign" COMMAND ${_tip_both_no_rpm_configure_command})
+_tip_assert_checksum_configuration("${_tip_both_no_rpm_build_dir}")
 
 set(_tip_both_no_rpm_package "${_tip_both_no_rpm_package_dir}/proof-both-no-rpm.tar.gz")
 file(WRITE "${_tip_both_no_rpm_package}" "tgz\n")
@@ -215,8 +232,7 @@ _tip_proof_run_step(
   "${_tip_both_no_rpm_build_dir}/sign_packages.cmake")
 
 _tip_proof_assert_exists("${_tip_both_no_rpm_package_dir}/proof-both-no-rpm.tar.gz.sig")
-_tip_proof_assert_exists("${_tip_both_no_rpm_package_dir}/proof-both-no-rpm.tar.gz.sha256")
-_tip_proof_assert_exists("${_tip_both_no_rpm_package_dir}/proof-both-no-rpm.tar.gz.sha512")
+_tip_assert_manual_checksum_result("${_tip_both_no_rpm_package}")
 
 file(
   WRITE "${_tip_checksums_off_source_dir}/CMakeLists.txt"
@@ -263,30 +279,33 @@ file(
   "target_install_package(proof_checksums_only_lib)\n"
   "export_cpack(PACKAGE_NAME ProofChecksumsOnly GENERATORS TGZ GENERATE_CHECKSUMS ON)\n")
 
-set(_tip_checksums_only_configure_command
-    "${CMAKE_COMMAND}" -E env "GPG_SIGNING_KEY=" "${CMAKE_COMMAND}" -S "${_tip_checksums_only_source_dir}" -B "${_tip_checksums_only_build_dir}" "-DCMAKE_BUILD_TYPE=Release"
-    ${_tip_toolchain_args})
+set(_tip_checksums_only_configure_command "${CMAKE_COMMAND}" -E env "GPG_SIGNING_KEY=" "${CMAKE_COMMAND}" -S "${_tip_checksums_only_source_dir}" -B "${_tip_checksums_only_build_dir}"
+                                          "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
 
 _tip_proof_run_step(NAME "checksums-only-configure-without-signing-key" COMMAND ${_tip_checksums_only_configure_command})
-_tip_proof_assert_file_contains("${_tip_checksums_only_build_dir}/sign_packages.cmake" "set(SIGNING_METHOD \"none\")")
-_tip_proof_assert_file_contains("${_tip_checksums_only_build_dir}/sign_packages.cmake" "set(GPG_EXECUTABLE \"\")")
+_tip_assert_checksum_configuration("${_tip_checksums_only_build_dir}")
 
 set(_tip_checksums_only_package "${_tip_checksums_only_package_dir}/proof-checksums-only.tar.gz")
 file(WRITE "${_tip_checksums_only_package}" "tgz\n")
 file(WRITE "${_tip_checksums_only_package}.sig" "stale signature\n")
 
-_tip_proof_run_step(
-  NAME
-  "run-checksums-only-script-pass"
-  COMMAND
-  "${CMAKE_COMMAND}"
-  "-DCPACK_PACKAGE_DIRECTORY=${_tip_checksums_only_package_dir}"
-  -P
-  "${_tip_checksums_only_build_dir}/sign_packages.cmake")
-
-_tip_proof_assert_not_exists("${_tip_checksums_only_package_dir}/proof-checksums-only.tar.gz.sig")
-_tip_proof_assert_exists("${_tip_checksums_only_package_dir}/proof-checksums-only.tar.gz.sha256")
-_tip_proof_assert_exists("${_tip_checksums_only_package_dir}/proof-checksums-only.tar.gz.sha512")
+if(CMAKE_VERSION VERSION_LESS "4.2")
+  _tip_proof_assert_file_contains("${_tip_checksums_only_build_dir}/sign_packages.cmake" "set(SIGNING_METHOD \"none\")")
+  _tip_proof_assert_file_contains("${_tip_checksums_only_build_dir}/sign_packages.cmake" "set(GPG_EXECUTABLE \"\")")
+  _tip_proof_run_step(
+    NAME
+    "run-checksums-only-script-pass"
+    COMMAND
+    "${CMAKE_COMMAND}"
+    "-DCPACK_PACKAGE_DIRECTORY=${_tip_checksums_only_package_dir}"
+    -P
+    "${_tip_checksums_only_build_dir}/sign_packages.cmake")
+  _tip_proof_assert_not_exists("${_tip_checksums_only_package_dir}/proof-checksums-only.tar.gz.sig")
+  _tip_proof_assert_exists("${_tip_checksums_only_package_dir}/proof-checksums-only.tar.gz.sha256")
+  _tip_proof_assert_exists("${_tip_checksums_only_package_dir}/proof-checksums-only.tar.gz.sha512")
+else()
+  _tip_proof_assert_not_exists("${_tip_checksums_only_build_dir}/sign_packages.cmake")
+endif()
 
 file(
   WRITE "${_tip_explicit_sign_no_key_source_dir}/CMakeLists.txt"
@@ -298,9 +317,8 @@ file(
   "target_install_package(proof_explicit_sign_no_key_lib)\n"
   "export_cpack(PACKAGE_NAME ProofExplicitSignNoKey GENERATORS TGZ SIGNING_METHOD detached GENERATE_CHECKSUMS ON)\n")
 
-set(_tip_explicit_sign_no_key_configure_command
-    "${CMAKE_COMMAND}" -E env "GPG_SIGNING_KEY=" "${CMAKE_COMMAND}" -S "${_tip_explicit_sign_no_key_source_dir}" -B "${_tip_explicit_sign_no_key_build_dir}"
-    "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
+set(_tip_explicit_sign_no_key_configure_command "${CMAKE_COMMAND}" -E env "GPG_SIGNING_KEY=" "${CMAKE_COMMAND}" -S "${_tip_explicit_sign_no_key_source_dir}" -B
+                                                "${_tip_explicit_sign_no_key_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
 
 _tip_proof_expect_failure(
   NAME
@@ -321,9 +339,8 @@ file(
   "target_install_package(proof_invalid_signing_method_lib)\n"
   "export_cpack(PACKAGE_NAME ProofInvalidSigningMethod GENERATORS TGZ SIGNING_METHOD bananas)\n")
 
-set(_tip_invalid_signing_method_configure_command
-    "${CMAKE_COMMAND}" -E env "GPG_SIGNING_KEY=" "${CMAKE_COMMAND}" -S "${_tip_invalid_signing_method_source_dir}" -B "${_tip_invalid_signing_method_build_dir}"
-    "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
+set(_tip_invalid_signing_method_configure_command "${CMAKE_COMMAND}" -E env "GPG_SIGNING_KEY=" "${CMAKE_COMMAND}" -S "${_tip_invalid_signing_method_source_dir}" -B
+                                                  "${_tip_invalid_signing_method_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
 
 _tip_proof_expect_failure(
   NAME
@@ -344,9 +361,8 @@ file(
   "target_install_package(proof_invalid_checksums_lib)\n"
   "export_cpack(PACKAGE_NAME ProofInvalidChecksums GENERATORS TGZ GENERATE_CHECKSUMS maybe)\n")
 
-set(_tip_invalid_checksums_configure_command
-    "${CMAKE_COMMAND}" -E env "GPG_SIGNING_KEY=" "${CMAKE_COMMAND}" -S "${_tip_invalid_checksums_source_dir}" -B "${_tip_invalid_checksums_build_dir}" "-DCMAKE_BUILD_TYPE=Release"
-    ${_tip_toolchain_args})
+set(_tip_invalid_checksums_configure_command "${CMAKE_COMMAND}" -E env "GPG_SIGNING_KEY=" "${CMAKE_COMMAND}" -S "${_tip_invalid_checksums_source_dir}" -B "${_tip_invalid_checksums_build_dir}"
+                                             "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
 
 _tip_proof_expect_failure(
   NAME

--- a/tests/cmake/proof_sbom_install_test.cmake
+++ b/tests/cmake/proof_sbom_install_test.cmake
@@ -26,6 +26,20 @@ file(MAKE_DIRECTORY "${_tip_fixture_source_dir}/src")
 
 _tip_proof_append_toolchain_args(_tip_toolchain_args)
 
+set(_tip_cross_export_fixture "")
+set(_tip_package_url_argument "")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+  set(_tip_package_url_argument " SBOM_PACKAGE_URL \"pkg:generic/proof-sbom@2.3.4\"")
+  string(
+    APPEND
+    _tip_cross_export_fixture
+    "add_library(sbom_extra STATIC src/extra.cpp)\n"
+    "target_install_package(sbom_extra EXPORT_NAME proof_sbom_extra VERSION \${PROJECT_VERSION} "
+    "SBOM SBOM_NAME ProofSbom SBOM_DESTINATION \"share/sbom/proofsbom\" SBOM_LICENSE \"MIT\" "
+    "SBOM_DESCRIPTION \"Proof SBOM package\" SBOM_HOMEPAGE_URL \"https://example.invalid/proof-sbom\" "
+    "SBOM_PACKAGE_URL \"pkg:generic/proof-sbom@2.3.4\")\n")
+endif()
+
 file(
   WRITE "${_tip_fixture_source_dir}/CMakeLists.txt"
   "cmake_minimum_required(VERSION 3.25)\n"
@@ -40,7 +54,7 @@ file(
   "target_install_package(sbom_static EXPORT_NAME proof_sbom_pkg VERSION \${PROJECT_VERSION} "
   "SBOM SBOM_NAME ProofSbom SBOM_DESTINATION \"share/sbom/proofsbom\" SBOM_LICENSE \"MIT\" "
   "SBOM_DESCRIPTION \"Proof SBOM package\" SBOM_HOMEPAGE_URL "
-  "\"https://example.invalid/proof-sbom\")\n"
+  "\"https://example.invalid/proof-sbom\"${_tip_package_url_argument})\n"
   "add_library(sbom_shared SHARED src/shared.cpp)\n"
   "target_compile_features(sbom_shared PUBLIC cxx_std_17)\n"
   "target_sources(sbom_shared PUBLIC FILE_SET HEADERS BASE_DIRS \"\${CMAKE_CURRENT_SOURCE_DIR}/include\" FILES \"include/proof_sbom/shared.hpp\")\n"
@@ -50,16 +64,18 @@ file(
   "target_install_package(sbom_shared EXPORT_NAME proof_sbom_pkg VERSION \${PROJECT_VERSION} "
   "SBOM SBOM_NAME ProofSbom SBOM_DESTINATION \"share/sbom/proofsbom\" SBOM_LICENSE \"MIT\" "
   "SBOM_DESCRIPTION \"Proof SBOM package\" SBOM_HOMEPAGE_URL "
-  "\"https://example.invalid/proof-sbom\")\n"
+  "\"https://example.invalid/proof-sbom\"${_tip_package_url_argument})\n"
   "add_library(sbom_iface INTERFACE)\n"
   "target_sources(sbom_iface INTERFACE FILE_SET HEADERS BASE_DIRS \"\${CMAKE_CURRENT_SOURCE_DIR}/include\" FILES \"include/proof_sbom/iface.hpp\")\n"
-  "target_install_package(sbom_iface EXPORT_NAME proof_sbom_pkg VERSION \${PROJECT_VERSION})\n")
+  "target_install_package(sbom_iface EXPORT_NAME proof_sbom_pkg VERSION \${PROJECT_VERSION})\n"
+  "${_tip_cross_export_fixture}")
 
 file(WRITE "${_tip_fixture_source_dir}/include/proof_sbom/static.hpp" "int sbom_static_value();\n")
 file(WRITE "${_tip_fixture_source_dir}/include/proof_sbom/shared.hpp" "int sbom_shared_value();\n")
 file(WRITE "${_tip_fixture_source_dir}/include/proof_sbom/iface.hpp" "#pragma once\n")
 file(WRITE "${_tip_fixture_source_dir}/src/static.cpp" "#include <proof_sbom/static.hpp>\nint sbom_static_value() { return 3; }\n")
 file(WRITE "${_tip_fixture_source_dir}/src/shared.cpp" "#include <proof_sbom/shared.hpp>\nint sbom_shared_value() { return 4; }\n")
+file(WRITE "${_tip_fixture_source_dir}/src/extra.cpp" "int sbom_extra_value() { return 5; }\n")
 
 set(_tip_fixture_configure_command "${CMAKE_COMMAND}" -S "${_tip_fixture_source_dir}" -B "${_tip_fixture_build_dir}" "-DCMAKE_BUILD_TYPE=Release" ${_tip_toolchain_args})
 
@@ -97,9 +113,17 @@ _tip_proof_assert_json_path_string("${_tip_sbom_file}" "https://spdx.org/rdf/3.0
 _tip_proof_find_spdx_document("${_tip_sbom_file}" "ProofSbom" _tip_document_index)
 _tip_proof_assert_json_path_string("${_tip_sbom_file}" "MIT" "@graph" ${_tip_document_index} "dataLicense")
 _tip_proof_assert_json_path_string("${_tip_sbom_file}" "Proof SBOM package" "@graph" ${_tip_document_index} "description")
-_tip_proof_assert_root_element_names("${_tip_sbom_file}" "${_tip_document_index}" "sbom_static" "sbom_shared" "sbom_iface")
+set(_tip_expected_root_elements sbom_static sbom_shared sbom_iface)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+  list(APPEND _tip_expected_root_elements sbom_extra)
+endif()
+_tip_proof_assert_root_element_names("${_tip_sbom_file}" "${_tip_document_index}" ${_tip_expected_root_elements})
 _tip_proof_assert_root_element("${_tip_sbom_file}" "${_tip_document_index}" "sbom_static" "2.3.4" "https://example.invalid/proof-sbom")
 _tip_proof_assert_root_element("${_tip_sbom_file}" "${_tip_document_index}" "sbom_shared" "2.3.4" "https://example.invalid/proof-sbom")
 _tip_proof_assert_root_element("${_tip_sbom_file}" "${_tip_document_index}" "sbom_iface" "2.3.4" "https://example.invalid/proof-sbom")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+  _tip_proof_assert_root_element_json_path_string("${_tip_sbom_file}" "${_tip_document_index}" "sbom_static" "pkg:generic/proof-sbom@2.3.4" "software_downloadLocation")
+  _tip_proof_assert_root_element("${_tip_sbom_file}" "${_tip_document_index}" "sbom_extra" "2.3.4" "https://example.invalid/proof-sbom")
+endif()
 
 message(STATUS "[proof] SBOM install proof passed.")

--- a/tests/cmake/proof_sbom_metadata_conflict_test.cmake
+++ b/tests/cmake/proof_sbom_metadata_conflict_test.cmake
@@ -37,30 +37,21 @@ function(_tip_proof_write_conflict_fixture case_name first_install second_instal
   file(MAKE_DIRECTORY "${_tip_source_dir}/first/src")
   file(MAKE_DIRECTORY "${_tip_source_dir}/second/src")
 
-  file(
-    WRITE "${_tip_source_dir}/CMakeLists.txt"
-    "cmake_minimum_required(VERSION 3.25)\n"
-    "project(proof_sbom_metadata_conflict_root VERSION 1.2.3 LANGUAGES CXX)\n"
-    "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
-    "add_subdirectory(first)\n"
-    "add_subdirectory(second)\n")
+  file(WRITE "${_tip_source_dir}/CMakeLists.txt" "cmake_minimum_required(VERSION 3.25)\n" "project(proof_sbom_metadata_conflict_root VERSION 1.2.3 LANGUAGES CXX)\n"
+                                                 "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n" "add_subdirectory(first)\n" "add_subdirectory(second)\n")
 
   file(
     WRITE "${_tip_source_dir}/first/CMakeLists.txt"
     "project(${_tip_first_project} VERSION 1.2.3 SPDX_LICENSE \"MIT\" DESCRIPTION \"First project metadata\" HOMEPAGE_URL \"https://example.invalid/first\" LANGUAGES CXX)\n"
-    "set(CMAKE_EXPERIMENTAL_GENERATE_SBOM \"${TIP_SBOM_EXPERIMENTAL_VALUE}\")\n"
-    "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
-    "add_library(first_lib STATIC src/first.cpp)\n"
-    "${first_install}\n")
+    "set(CMAKE_EXPERIMENTAL_GENERATE_SBOM \"${TIP_SBOM_EXPERIMENTAL_VALUE}\")\n" "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+    "add_library(first_lib STATIC src/first.cpp)\n" "${first_install}\n")
   file(WRITE "${_tip_source_dir}/first/src/first.cpp" "int first_lib_value() { return 1; }\n")
 
   file(
     WRITE "${_tip_source_dir}/second/CMakeLists.txt"
     "project(${_tip_second_project} VERSION 1.2.3 SPDX_LICENSE \"Apache-2.0\" DESCRIPTION \"Second project metadata\" HOMEPAGE_URL \"https://example.invalid/second\" LANGUAGES CXX)\n"
-    "set(CMAKE_EXPERIMENTAL_GENERATE_SBOM \"${TIP_SBOM_EXPERIMENTAL_VALUE}\")\n"
-    "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
-    "add_library(second_lib STATIC src/second.cpp)\n"
-    "${second_install}\n")
+    "set(CMAKE_EXPERIMENTAL_GENERATE_SBOM \"${TIP_SBOM_EXPERIMENTAL_VALUE}\")\n" "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+    "add_library(second_lib STATIC src/second.cpp)\n" "${second_install}\n")
   file(WRITE "${_tip_source_dir}/second/src/second.cpp" "int second_lib_value() { return 2; }\n")
 
   _tip_proof_expect_failure(
@@ -80,14 +71,41 @@ function(_tip_proof_write_conflict_fixture case_name first_install second_instal
 endfunction()
 
 _tip_proof_write_conflict_fixture(
-  "inherit-then-none"
-  "target_install_package(first_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME FirstProject SBOM_DESTINATION \"share/sbom/conflict\")"
+  "inherit-then-none" "target_install_package(first_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME FirstProject SBOM_DESTINATION \"share/sbom/conflict\")"
   "target_install_package(second_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME FirstProject SBOM_NO_PROJECT_METADATA SBOM_DESTINATION \"share/sbom/conflict\")")
 
 _tip_proof_write_conflict_fixture(
-  "none-then-inherit"
-  "target_install_package(first_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME SecondProject SBOM_NO_PROJECT_METADATA SBOM_DESTINATION \"share/sbom/conflict\")"
+  "none-then-inherit" "target_install_package(first_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME SecondProject SBOM_NO_PROJECT_METADATA SBOM_DESTINATION \"share/sbom/conflict\")"
   "target_install_package(second_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME SecondProject SBOM_DESTINATION \"share/sbom/conflict\")")
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+  set(_tip_cross_export_source_dir "${_tip_case_root}/cross-export-package-url-src")
+  set(_tip_cross_export_build_dir "${_tip_case_root}/cross-export-package-url-build")
+  file(MAKE_DIRECTORY "${_tip_cross_export_source_dir}")
+  file(
+    WRITE "${_tip_cross_export_source_dir}/CMakeLists.txt"
+    "cmake_minimum_required(VERSION 4.4)\n"
+    "project(proof_sbom_cross_export_conflict VERSION 1.2.3 LANGUAGES CXX)\n"
+    "set(CMAKE_EXPERIMENTAL_GENERATE_SBOM \"${TIP_SBOM_EXPERIMENTAL_VALUE}\")\n"
+    "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+    "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+    "add_library(first INTERFACE)\n"
+    "target_install_package(first EXPORT_NAME FirstExport VERSION 1.2.3 SBOM SBOM_NAME Combined SBOM_NO_PROJECT_METADATA SBOM_PACKAGE_URL \"pkg:generic/first@1.2.3\")\n"
+    "add_library(second INTERFACE)\n"
+    "target_install_package(second EXPORT_NAME SecondExport VERSION 1.2.3 SBOM SBOM_NAME Combined SBOM_NO_PROJECT_METADATA SBOM_PACKAGE_URL \"pkg:generic/second@1.2.3\")\n")
+  _tip_proof_expect_failure(
+    NAME
+    "cross-export-package-url-conflict"
+    COMMAND
+    "${CMAKE_COMMAND}"
+    -S
+    "${_tip_cross_export_source_dir}"
+    -B
+    "${_tip_cross_export_build_dir}"
+    ${_tip_toolchain_args}
+    EXPECT_CONTAINS
+    "url for SBOM 'Combined' across exports")
+endif()
 
 _tip_proof_write_conflict_fixture(
   "project-a-then-project-b"
@@ -102,13 +120,11 @@ _tip_proof_write_conflict_fixture(
   "FirstProject")
 
 _tip_proof_write_conflict_fixture(
-  "inherit-then-explicit"
-  "target_install_package(first_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME FirstProject SBOM_DESTINATION \"share/sbom/conflict\")"
+  "inherit-then-explicit" "target_install_package(first_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME FirstProject SBOM_DESTINATION \"share/sbom/conflict\")"
   "target_install_package(second_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME FirstProject SBOM_DESTINATION \"share/sbom/conflict\")")
 
 _tip_proof_write_conflict_fixture(
-  "explicit-then-inherit"
-  "target_install_package(first_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME SecondProject SBOM_DESTINATION \"share/sbom/conflict\")"
+  "explicit-then-inherit" "target_install_package(first_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME SecondProject SBOM_DESTINATION \"share/sbom/conflict\")"
   "target_install_package(second_lib EXPORT_NAME SharedConflictExport VERSION 1.2.3 SBOM SBOM_NAME SecondProject SBOM_DESTINATION \"share/sbom/conflict\")")
 
 message(STATUS "[proof] SBOM metadata conflict proof passed.")

--- a/tests/cmake/proof_sbom_multi_export_guard_test.cmake
+++ b/tests/cmake/proof_sbom_multi_export_guard_test.cmake
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.25)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+if(NOT DEFINED TIP_SBOM_EXPERIMENTAL_VALUE OR TIP_SBOM_EXPERIMENTAL_VALUE STREQUAL "")
+  _tip_proof_fail("TIP_SBOM_EXPERIMENTAL_VALUE is required")
+endif()
+if(CMAKE_VERSION VERSION_LESS "4.3" OR CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+  _tip_proof_fail("proof_sbom_multi_export_guard requires CMake 4.3.x")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/sbom-multi-export-guard")
+set(_tip_source_dir "${_tip_case_root}/src")
+set(_tip_build_dir "${_tip_case_root}/build")
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_source_dir}")
+
+file(
+  WRITE "${_tip_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 4.3)\n"
+  "project(proof_sbom_multi_export_guard VERSION 1.0.0 LANGUAGES CXX)\n"
+  "set(CMAKE_EXPERIMENTAL_GENERATE_SBOM \"${TIP_SBOM_EXPERIMENTAL_VALUE}\")\n"
+  "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+  "add_library(first INTERFACE)\n"
+  "target_install_package(first EXPORT_NAME first_export VERSION 1.0.0 SBOM SBOM_NAME Combined SBOM_NO_PROJECT_METADATA)\n"
+  "add_library(second INTERFACE)\n"
+  "target_install_package(second EXPORT_NAME second_export VERSION 1.0.0 SBOM SBOM_NAME Combined SBOM_NO_PROJECT_METADATA)\n")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+_tip_proof_expect_failure(
+  NAME
+  "multi-export-on-cmake-43"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  -S
+  "${_tip_source_dir}"
+  -B
+  "${_tip_build_dir}"
+  ${_tip_toolchain_args}
+  EXPECT_CONTAINS
+  "sets into one SBOM requires CMake 4.4 or newer")
+
+set(_tip_package_url_source_dir "${_tip_case_root}/package-url-src")
+set(_tip_package_url_build_dir "${_tip_case_root}/package-url-build")
+file(MAKE_DIRECTORY "${_tip_package_url_source_dir}")
+file(
+  WRITE "${_tip_package_url_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 4.3)\n"
+  "project(proof_sbom_package_url_guard VERSION 1.0.0 LANGUAGES CXX)\n"
+  "set(CMAKE_EXPERIMENTAL_GENERATE_SBOM \"${TIP_SBOM_EXPERIMENTAL_VALUE}\")\n"
+  "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+  "add_library(package_url INTERFACE)\n"
+  "target_install_package(package_url VERSION 1.0.0 SBOM SBOM_NO_PROJECT_METADATA SBOM_PACKAGE_URL \"pkg:generic/package-url@1.0.0\")\n")
+_tip_proof_expect_failure(
+  NAME
+  "package-url-on-cmake-43"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  -S
+  "${_tip_package_url_source_dir}"
+  -B
+  "${_tip_package_url_build_dir}"
+  ${_tip_toolchain_args}
+  EXPECT_CONTAINS
+  "4.4 or newer because CMake 4.3 does not accept PACKAGE_URL")
+
+message(STATUS "[proof] CMake 4.3 multi-export SBOM guard proof passed.")

--- a/tests/cmake/proof_source_file_sets_failures_test.cmake
+++ b/tests/cmake/proof_source_file_sets_failures_test.cmake
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 4.4)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/source-file-set-failures")
+set(_tip_cps_source_dir "${_tip_case_root}/cps-src")
+set(_tip_cps_build_dir "${_tip_case_root}/cps-build")
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_cps_source_dir}/src")
+file(WRITE "${_tip_cps_source_dir}/src/source.cpp" "int source_value() { return 42; }\n")
+file(
+  WRITE "${_tip_cps_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 4.4)\n"
+  "project(proof_source_cps_failure VERSION 1.0.0 LANGUAGES CXX)\n"
+  "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+  "add_library(source_only INTERFACE)\n"
+  "target_sources(source_only INTERFACE FILE_SET implementation TYPE SOURCES BASE_DIRS \"\${CMAKE_CURRENT_SOURCE_DIR}/src\" FILES \"\${CMAKE_CURRENT_SOURCE_DIR}/src/source.cpp\")\n"
+  "target_install_package(source_only EXPORT_NAME source_cps CPS CPS_NO_PROJECT_METADATA VERSION 1.0.0)\n")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+_tip_proof_expect_failure(
+  NAME
+  "cps-source-set-rejection"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  -S
+  "${_tip_cps_source_dir}"
+  -B
+  "${_tip_cps_build_dir}"
+  ${_tip_toolchain_args}
+  EXPECT_CONTAINS
+  "is not supported with SOURCES file sets")
+
+message(STATUS "[proof] CMake 4.4 source file set failure proof passed.")

--- a/tests/cmake/proof_source_file_sets_old_cmake_guard_test.cmake
+++ b/tests/cmake/proof_source_file_sets_old_cmake_guard_test.cmake
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.25)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.4")
+  _tip_proof_fail("proof_source_file_sets_old_cmake_guard requires CMake older than 4.4")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/source-file-sets-old-cmake-guard")
+set(_tip_source_dir "${_tip_case_root}/src")
+set(_tip_build_dir "${_tip_case_root}/build")
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_source_dir}")
+file(WRITE "${_tip_source_dir}/source.cpp.in" "int configured_source() { return 42; }\n")
+file(
+  WRITE "${_tip_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 3.25)\n" "project(proof_source_old_cmake_guard LANGUAGES CXX)\n" "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n" "add_library(source_only INTERFACE)\n" "target_configure_sources(source_only INTERFACE TYPE SOURCES FILES source.cpp.in)\n")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+_tip_proof_expect_failure(
+  NAME
+  "configured-source-on-old-cmake"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  -S
+  "${_tip_source_dir}"
+  -B
+  "${_tip_build_dir}"
+  ${_tip_toolchain_args}
+  EXPECT_CONTAINS
+  "SOURCES requires CMake 4.4 or newer")
+
+message(STATUS "[proof] CMake 4.4 source file set old-CMake guard proof passed.")

--- a/tests/cmake/proof_source_file_sets_test.cmake
+++ b/tests/cmake/proof_source_file_sets_test.cmake
@@ -1,0 +1,128 @@
+cmake_minimum_required(VERSION 4.4)
+
+include("${CMAKE_CURRENT_LIST_DIR}/proof_helpers.cmake")
+
+if(NOT DEFINED TIP_REPO_ROOT)
+  _tip_proof_fail("TIP_REPO_ROOT is required")
+endif()
+if(NOT DEFINED TIP_PROOF_TEST_ROOT)
+  _tip_proof_fail("TIP_PROOF_TEST_ROOT is required")
+endif()
+
+set(_tip_case_root "${TIP_PROOF_TEST_ROOT}/source-file-sets")
+set(_tip_fixture_source_dir "${_tip_case_root}/fixture-src")
+set(_tip_fixture_build_dir "${_tip_case_root}/fixture-build")
+set(_tip_install_prefix "${_tip_case_root}/fixture-install")
+set(_tip_consumer_source_dir "${_tip_case_root}/consumer-src")
+set(_tip_consumer_build_dir "${_tip_case_root}/consumer-build")
+
+file(REMOVE_RECURSE "${_tip_case_root}")
+file(MAKE_DIRECTORY "${_tip_fixture_source_dir}/include/proof" "${_tip_fixture_source_dir}/src" "${_tip_fixture_source_dir}/custom")
+
+file(WRITE "${_tip_fixture_source_dir}/include/proof/source.hpp" "#pragma once\nint source_value();\nint generated_value();\n")
+file(WRITE "${_tip_fixture_source_dir}/src/source.cpp" "#include <proof/source.hpp>\nint source_value() { return 40; }\n")
+file(WRITE "${_tip_fixture_source_dir}/src/generated.cpp.in" "#include <proof/source.hpp>\nint generated_value() { return @GENERATED_VALUE@; }\n")
+file(WRITE "${_tip_fixture_source_dir}/custom/custom.cpp" "int custom_source_value() { return 7; }\n")
+
+file(
+  WRITE "${_tip_fixture_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 4.4)\n"
+  "project(proof_source_file_sets VERSION 1.0.0 LANGUAGES CXX)\n"
+  "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+  "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+  "add_library(source_only INTERFACE)\n"
+  "target_sources(source_only INTERFACE FILE_SET api TYPE HEADERS BASE_DIRS \"\${CMAKE_CURRENT_SOURCE_DIR}/include\" FILES \"\${CMAKE_CURRENT_SOURCE_DIR}/include/proof/source.hpp\")\n"
+  "target_sources(source_only INTERFACE FILE_SET implementation TYPE SOURCES BASE_DIRS \"\${CMAKE_CURRENT_SOURCE_DIR}/src\" FILES \"\${CMAKE_CURRENT_SOURCE_DIR}/src/source.cpp\")\n"
+  "set(GENERATED_VALUE 2)\n"
+  "target_configure_sources(source_only INTERFACE TYPE SOURCES FILE_SET generated_implementation OUTPUT_DIR \"\${CMAKE_CURRENT_BINARY_DIR}/generated\" BASE_DIRS \"\${CMAKE_CURRENT_BINARY_DIR}/generated\" FILES src/generated.cpp.in)\n"
+  "set_property(FILE_SET implementation TARGET source_only PROPERTY SKIP_LINTING ON)\n"
+  "set_property(FILE_SET implementation TARGET source_only PROPERTY SKIP_PRECOMPILE_HEADERS ON)\n"
+  "set_property(FILE_SET implementation TARGET source_only PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)\n"
+  "target_install_package(source_only EXPORT_NAME proof_source_pkg NAMESPACE proof:: VERSION 1.0.0)\n"
+  "add_library(custom_source_only INTERFACE)\n"
+  "target_sources(custom_source_only INTERFACE FILE_SET implementation TYPE SOURCES BASE_DIRS \"\${CMAKE_CURRENT_SOURCE_DIR}/custom\" FILES \"\${CMAKE_CURRENT_SOURCE_DIR}/custom/custom.cpp\")\n"
+  "target_install_package(custom_source_only EXPORT_NAME custom_source_pkg SOURCE_DESTINATION share/custom-source VERSION 1.0.0)\n")
+
+_tip_proof_append_toolchain_args(_tip_toolchain_args)
+_tip_proof_run_step(
+  NAME
+  "fixture-configure"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  -S
+  "${_tip_fixture_source_dir}"
+  -B
+  "${_tip_fixture_build_dir}"
+  ${_tip_toolchain_args})
+_tip_proof_run_step(
+  NAME
+  "fixture-install"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --install
+  "${_tip_fixture_build_dir}"
+  --prefix
+  "${_tip_install_prefix}")
+
+_tip_proof_assert_exists("${_tip_install_prefix}/share/proof_source_pkg/src/source.cpp")
+_tip_proof_assert_exists("${_tip_install_prefix}/share/proof_source_pkg/src/generated.cpp")
+_tip_proof_assert_exists("${_tip_install_prefix}/share/custom-source/custom.cpp")
+_tip_proof_assert_exists("${_tip_install_prefix}/include/proof/source.hpp")
+
+file(REMOVE_RECURSE "${_tip_fixture_source_dir}" "${_tip_fixture_build_dir}")
+file(MAKE_DIRECTORY "${_tip_consumer_source_dir}")
+file(
+  WRITE "${_tip_consumer_source_dir}/CMakeLists.txt"
+  "cmake_minimum_required(VERSION 4.4)\n"
+  "project(proof_source_consumer LANGUAGES CXX)\n"
+  "find_package(proof_source_pkg 1.0 CONFIG REQUIRED PATHS \"${_tip_install_prefix}\" NO_DEFAULT_PATH)\n"
+  "get_target_property(source_sets proof::source_only INTERFACE_SOURCE_SETS)\n"
+  "foreach(expected implementation generated_implementation)\n"
+  "  if(NOT expected IN_LIST source_sets)\n"
+  "    message(FATAL_ERROR \"Missing installed source set: \${expected}; got: \${source_sets}\")\n"
+  "  endif()\n"
+  "  get_target_property(source_files proof::source_only SOURCE_SET_\${expected})\n"
+  "  foreach(source_file IN LISTS source_files)\n"
+  "    string(FIND \"\${source_file}\" \"${_tip_install_prefix}/\" prefix_index)\n"
+  "    if(NOT prefix_index EQUAL 0)\n"
+  "      message(FATAL_ERROR \"Source set path escaped the relocated prefix: \${source_file}\")\n"
+  "    endif()\n"
+  "  endforeach()\n"
+  "endforeach()\n"
+  "add_executable(proof_source_consumer main.cpp)\n"
+  "target_link_libraries(proof_source_consumer PRIVATE proof::source_only)\n")
+file(WRITE "${_tip_consumer_source_dir}/main.cpp" "#include <proof/source.hpp>\nint main() { return source_value() + generated_value() == 42 ? 0 : 1; }\n")
+
+_tip_proof_run_step(
+  NAME
+  "consumer-configure"
+  COMMAND
+  "${CMAKE_COMMAND}"
+  -S
+  "${_tip_consumer_source_dir}"
+  -B
+  "${_tip_consumer_build_dir}"
+  ${_tip_toolchain_args})
+_tip_proof_run_step(NAME "consumer-build" COMMAND "${CMAKE_COMMAND}" --build "${_tip_consumer_build_dir}")
+_tip_proof_run_step(NAME "consumer-run" COMMAND "${_tip_consumer_build_dir}/proof_source_consumer${CMAKE_EXECUTABLE_SUFFIX}")
+
+if(DEFINED TIP_OLD_CMAKE_COMMAND AND NOT "${TIP_OLD_CMAKE_COMMAND}" STREQUAL "")
+  set(_tip_old_consumer_source_dir "${_tip_case_root}/old-consumer-src")
+  set(_tip_old_consumer_build_dir "${_tip_case_root}/old-consumer-build")
+  file(MAKE_DIRECTORY "${_tip_old_consumer_source_dir}")
+  file(WRITE "${_tip_old_consumer_source_dir}/CMakeLists.txt" "cmake_minimum_required(VERSION 3.25)\n" "project(proof_source_old_consumer LANGUAGES NONE)\n"
+                                                              "find_package(proof_source_pkg CONFIG REQUIRED PATHS \"${_tip_install_prefix}\" NO_DEFAULT_PATH)\n")
+  _tip_proof_expect_failure(
+    NAME
+    "old-consumer-version-guard"
+    COMMAND
+    "${TIP_OLD_CMAKE_COMMAND}"
+    -S
+    "${_tip_old_consumer_source_dir}"
+    -B
+    "${_tip_old_consumer_build_dir}"
+    EXPECT_CONTAINS
+    "Package 'proof_source_pkg' contains SOURCES file sets")
+endif()
+
+message(STATUS "[proof] CMake 4.4 source file set proof passed.")


### PR DESCRIPTION
## Summary

- add CMake 4.4 package compatibility modes and explicit architecture-independent version files
- install and export `SOURCES` file sets with relocated source-only consumer proofs
- aggregate multiple exports into one SBOM and expose package URLs on CMake 4.4
- support all ten CPack checksum algorithms with native CMake 4.2+ and fallback paths
- pin the core, modules, CPack, SBOM, and latest CMake lanes and add Windows Ninja + clang-cl coverage
- prepare the curated `v7.1.0` release and signed self-release workflow

## Compatibility

The global minimum remains CMake 3.25. New capabilities fail with targeted version errors outside their feature floor. CMake 3.28.4 and 4.2.3 are used because those are the latest published patch releases in their respective minor lines. `SBOM_PACKAGE_URL` is gated on 4.4 because the 4.3 command parser rejects the documented argument. CPS output is rejected for source-only packages until an equivalent representation is proven.

## Validation

- CMake 3.25.0: configure, build, 41 tests, install
- CMake 3.28.4: C++ module build and install
- CMake 4.2.3: native all-algorithm CPack checksum proof
- CMake 4.3.4: five SBOM compatibility proofs
- CMake 4.4.2: configure with absolute-destination errors, build, header-set verification, 42 tests, install
- CMake 4.4.2: four aggregate SBOM/package URL proofs
- CMake 4.4.2: signed self-release archives, checksums, SPDX SBOM, package URL, and installed consumer
- fallback CPack checksum proof on CMake 3.25.0
- `actionlint`, `cmake-format --check`, JSON validation, and Bash syntax checks

Platform CI additionally covers the full compiler/OS matrix and Windows Ninja + clang-cl modules.