### PR TITLE
Add source file-set consumer hygiene controls

### DIFF
--- a/cmake/generic-config.cmake.in
+++ b/cmake/generic-config.cmake.in
@@ -36,6 +36,8 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@ARG_EXPORT_NAME@Targets.cmake")
 
+@PACKAGE_SOURCE_FILE_SET_PROPERTIES_CONTENT@
+
 if(_tip_restore_relwithdebinfo_map)
   set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO "${_tip_saved_relwithdebinfo_map}")
 else()

--- a/docs/source-only-packages.md
+++ b/docs/source-only-packages.md
@@ -39,12 +39,15 @@ Interface sources are compiled into every dependent target. This model works wel
 - Static state can be duplicated across binaries or shared libraries.
 - Consumer compile flags become part of the package's effective ABI.
 
-CMake 4.4 file-set properties can keep packaged sources out of consumer-wide tooling when appropriate:
+CMake 4.4 file-set properties can keep packaged sources out of consumer-wide tooling when appropriate. Pass them through `target_install_package()` as triples of file-set name, property, and boolean value:
 
 ```cmake
-set_property(FILE_SET implementation TARGET foo_sources PROPERTY SKIP_LINTING ON)
-set_property(FILE_SET implementation TARGET foo_sources PROPERTY SKIP_PRECOMPILE_HEADERS ON)
-set_property(FILE_SET implementation TARGET foo_sources PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+target_install_package(foo_sources
+  SOURCE_FILE_SET_PROPERTIES
+    implementation SKIP_LINTING ON
+    implementation SKIP_PRECOMPILE_HEADERS ON
+    implementation SKIP_UNITY_BUILD_INCLUSION ON
+    implementation CXX_SCAN_FOR_MODULES OFF)
 ```
 
-These controls are opt-in because some packages should inherit the consumer's analysis, precompiled-header, or unity-build settings.
+`SKIP_LINTING`, `SKIP_PRECOMPILE_HEADERS`, `SKIP_UNITY_BUILD_INCLUSION`, and `CXX_SCAN_FOR_MODULES` require CMake 4.4 and apply only to public or interface `SOURCES` file sets. These controls are opt-in because some packages should inherit the consumer's analysis, precompiled-header, unity-build, or module-scanning settings.

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -58,6 +58,7 @@ endif()
 #     INCLUDE_DESTINATION <include_dest>
 #     MODULE_DESTINATION <module_dest>
 #     SOURCE_DESTINATION <source_dest>
+#     SOURCE_FILE_SET_PROPERTIES <file_set> <property> <boolean> [...]
 #     CMAKE_CONFIG_DESTINATION <config_dest>
 #     COMPONENT <component>
 #     DEBUG_POSTFIX <postfix>
@@ -118,6 +119,8 @@ endif()
 #   INCLUDE_DESTINATION          - Destination for installed headers (default: `${CMAKE_INSTALL_INCLUDEDIR}`).
 #   MODULE_DESTINATION           - Destination for C++20 modules (default: `${CMAKE_INSTALL_INCLUDEDIR}`).
 #   SOURCE_DESTINATION           - Destination for CMake 4.4 SOURCES file sets (default: `${CMAKE_INSTALL_DATADIR}/${EXPORT_NAME}/src`).
+#   SOURCE_FILE_SET_PROPERTIES   - CMake 4.4 source file-set property triples: `<file_set> <property> <boolean>`. Supported properties are
+#                                  `SKIP_LINTING`, `SKIP_PRECOMPILE_HEADERS`, `SKIP_UNITY_BUILD_INCLUSION`, and `CXX_SCAN_FOR_MODULES`.
 #   CMAKE_CONFIG_DESTINATION     - Destination for CMake config files (default: `${CMAKE_INSTALL_DATADIR}/cmake/${EXPORT_NAME}`).
 #   COMPONENT                    - Optional runtime component name. Development files stay in the shared `Development` component.
 #                                  If omitted, uses default "Runtime" and "Development" components.
@@ -147,6 +150,7 @@ endif()
 #   - Installs headers, libraries, and config files for the target.
 #   - Handles both legacy PUBLIC_HEADER and modern FILE_SET installation.
 #   - Installs public and interface SOURCES file sets with CMake 4.4+.
+#   - Applies requested consumer-build hygiene controls to public and interface SOURCES file sets with CMake 4.4+.
 #   - Supports C++20 modules (CMake 3.28+).
 #   - Generates CMake config files with version and dependency handling.
 #   - Supports multi-config builds with automatic debug postfix handling.
@@ -584,6 +588,7 @@ endfunction()
 #     INCLUDE_DESTINATION <include_dest>
 #     MODULE_DESTINATION <module_dest>
 #     SOURCE_DESTINATION <source_dest>
+#     SOURCE_FILE_SET_PROPERTIES <file_set> <property> <boolean> [...]
 #     CMAKE_CONFIG_DESTINATION <config_dest>
 #     COMPONENT <component>
 #     DEBUG_POSTFIX <postfix>
@@ -694,6 +699,7 @@ function(target_prepare_package TARGET_NAME)
       INCLUDE_ON_FIND_PACKAGE
       PUBLIC_CMAKE_FILES
       COMPONENT_DEPENDENCIES
+      SOURCE_FILE_SET_PROPERTIES
       CPS_DEFAULT_TARGETS
       CPS_DEFAULT_CONFIGURATIONS
       CPS_PERMISSIONS
@@ -720,6 +726,72 @@ function(target_prepare_package TARGET_NAME)
   # Check if target exists
   if(NOT TARGET ${TARGET_NAME})
     project_log(FATAL_ERROR "Target '${TARGET_NAME}' does not exist.")
+  endif()
+
+  if(ARG_SOURCE_FILE_SET_PROPERTIES)
+    if(CMAKE_VERSION VERSION_LESS "4.4")
+      project_log(FATAL_ERROR "SOURCE_FILE_SET_PROPERTIES requires CMake 4.4 or newer.")
+    endif()
+
+    list(LENGTH ARG_SOURCE_FILE_SET_PROPERTIES _tip_source_file_set_property_count)
+    math(EXPR _tip_source_file_set_property_remainder "${_tip_source_file_set_property_count} % 3")
+    if(NOT _tip_source_file_set_property_remainder EQUAL 0)
+      project_log(FATAL_ERROR "SOURCE_FILE_SET_PROPERTIES for target '${TARGET_NAME}' requires `<file_set> <property> <boolean>` triples.")
+    endif()
+
+    get_target_property(_tip_interface_source_sets ${TARGET_NAME} INTERFACE_SOURCE_SETS)
+    if(NOT _tip_interface_source_sets OR _tip_interface_source_sets MATCHES "-NOTFOUND$")
+      set(_tip_interface_source_sets "")
+    endif()
+
+    set(_tip_supported_source_file_set_properties SKIP_LINTING SKIP_PRECOMPILE_HEADERS SKIP_UNITY_BUILD_INCLUSION CXX_SCAN_FOR_MODULES)
+    set(_tip_boolean_values
+        ON
+        OFF
+        TRUE
+        FALSE
+        YES
+        NO
+        Y
+        N
+        1
+        0)
+    set(_tip_source_file_set_property_index 0)
+    while(_tip_source_file_set_property_index LESS _tip_source_file_set_property_count)
+      list(GET ARG_SOURCE_FILE_SET_PROPERTIES ${_tip_source_file_set_property_index} _tip_source_file_set_name)
+      math(EXPR _tip_source_file_set_property_index "${_tip_source_file_set_property_index} + 1")
+      list(GET ARG_SOURCE_FILE_SET_PROPERTIES ${_tip_source_file_set_property_index} _tip_source_file_set_property)
+      math(EXPR _tip_source_file_set_property_index "${_tip_source_file_set_property_index} + 1")
+      list(GET ARG_SOURCE_FILE_SET_PROPERTIES ${_tip_source_file_set_property_index} _tip_source_file_set_value)
+      math(EXPR _tip_source_file_set_property_index "${_tip_source_file_set_property_index} + 1")
+
+      if(NOT _tip_source_file_set_name IN_LIST _tip_interface_source_sets)
+        project_log(FATAL_ERROR "SOURCE_FILE_SET_PROPERTIES file set '${_tip_source_file_set_name}' does not name an INTERFACE SOURCES file set on target '${TARGET_NAME}'.")
+      endif()
+
+      get_property(
+        _tip_source_file_set_type FILE_SET "${_tip_source_file_set_name}"
+        TARGET "${TARGET_NAME}"
+        PROPERTY TYPE)
+      if(NOT _tip_source_file_set_type STREQUAL "SOURCES")
+        project_log(FATAL_ERROR "SOURCE_FILE_SET_PROPERTIES file set '${_tip_source_file_set_name}' on target '${TARGET_NAME}' must have type SOURCES.")
+      endif()
+
+      if(NOT _tip_source_file_set_property IN_LIST _tip_supported_source_file_set_properties)
+        project_log(FATAL_ERROR "Unsupported SOURCE_FILE_SET_PROPERTIES property '${_tip_source_file_set_property}'. Supported properties: ${_tip_supported_source_file_set_properties}.")
+      endif()
+
+      string(TOUPPER "${_tip_source_file_set_value}" _tip_source_file_set_value_upper)
+      if(NOT _tip_source_file_set_value_upper IN_LIST _tip_boolean_values)
+        project_log(FATAL_ERROR "SOURCE_FILE_SET_PROPERTIES value '${_tip_source_file_set_value}' for '${_tip_source_file_set_property}' must be a boolean.")
+      endif()
+
+      set_property(
+        FILE_SET "${_tip_source_file_set_name}"
+        TARGET "${TARGET_NAME}"
+        PROPERTY "${_tip_source_file_set_property}" "${_tip_source_file_set_value}")
+      project_log(DEBUG "  Set ${_tip_source_file_set_property}=${_tip_source_file_set_value} on SOURCES file set '${_tip_source_file_set_name}'")
+    endwhile()
   endif()
 
   # Validate additional targets
@@ -1079,6 +1151,14 @@ function(target_prepare_package TARGET_NAME)
   set_property(GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_COMPONENT_EXPLICIT" "${_tip_component_explicit}")
   set_property(GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_ALIAS_NAME" "${ARG_ALIAS_NAME}")
   set_property(GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_ALIAS_NAME_EXPLICIT" "${_tip_alias_name_explicit}")
+
+  if(ARG_SOURCE_FILE_SET_PROPERTIES)
+    get_property(_tip_existing_source_file_set_properties GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_SOURCE_FILE_SET_PROPERTIES")
+    if(_tip_existing_source_file_set_properties AND NOT "${_tip_existing_source_file_set_properties}" STREQUAL "${ARG_SOURCE_FILE_SET_PROPERTIES}")
+      project_log(FATAL_ERROR "Conflicting SOURCE_FILE_SET_PROPERTIES for target '${TARGET_NAME}' in export '${ARG_EXPORT_NAME}'.")
+    endif()
+    set_property(GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_SOURCE_FILE_SET_PROPERTIES" "${ARG_SOURCE_FILE_SET_PROPERTIES}")
+  endif()
 
   foreach(_tip_additional_target IN LISTS ARG_ADDITIONAL_TARGETS)
     get_property(
@@ -1811,6 +1891,7 @@ function(finalize_package)
   set(_tip_cps_default_target_types STATIC_LIBRARY SHARED_LIBRARY INTERFACE_LIBRARY)
   set(_tip_cps_unsupported_target_types EXECUTABLE MODULE_LIBRARY)
   set(_tip_exported_alias_names "")
+  set(PACKAGE_SOURCE_FILE_SET_PROPERTIES_CONTENT "")
 
   # Install each target separately with its own components
   set(_tip_export_has_source_sets FALSE)
@@ -1870,6 +1951,23 @@ function(finalize_package)
     if(NOT TARGET_ALIAS_NAME STREQUAL TARGET_NAME)
       set_property(TARGET ${TARGET_NAME} PROPERTY EXPORT_NAME ${TARGET_ALIAS_NAME})
       project_log(DEBUG "Set EXPORT_NAME '${TARGET_ALIAS_NAME}' for target '${TARGET_NAME}'")
+    endif()
+
+    get_property(_tip_target_source_file_set_properties GLOBAL PROPERTY "${EXPORT_PROPERTY_PREFIX}_TARGET_${TARGET_NAME}_SOURCE_FILE_SET_PROPERTIES")
+    if(_tip_target_source_file_set_properties)
+      list(LENGTH _tip_target_source_file_set_properties _tip_target_source_file_set_property_count)
+      set(_tip_target_source_file_set_property_index 0)
+      while(_tip_target_source_file_set_property_index LESS _tip_target_source_file_set_property_count)
+        list(GET _tip_target_source_file_set_properties ${_tip_target_source_file_set_property_index} _tip_source_file_set_name)
+        math(EXPR _tip_target_source_file_set_property_index "${_tip_target_source_file_set_property_index} + 1")
+        list(GET _tip_target_source_file_set_properties ${_tip_target_source_file_set_property_index} _tip_source_file_set_property)
+        math(EXPR _tip_target_source_file_set_property_index "${_tip_target_source_file_set_property_index} + 1")
+        list(GET _tip_target_source_file_set_properties ${_tip_target_source_file_set_property_index} _tip_source_file_set_value)
+        math(EXPR _tip_target_source_file_set_property_index "${_tip_target_source_file_set_property_index} + 1")
+
+        string(APPEND PACKAGE_SOURCE_FILE_SET_PROPERTIES_CONTENT
+               "set_property(FILE_SET \"${_tip_source_file_set_name}\" TARGET \"${NAMESPACE}${TARGET_ALIAS_NAME}\" PROPERTY \"${_tip_source_file_set_property}\" \"${_tip_source_file_set_value}\")\n")
+      endwhile()
     endif()
 
     # Primary install with export (to base components)
@@ -1948,7 +2046,8 @@ function(finalize_package)
         if(CPS_ENABLED)
           project_log(
             FATAL_ERROR
-            "CPS package metadata for export '${ARG_EXPORT_NAME}' does not support SOURCES file sets. CMake 4.4.2 install(PACKAGE_INFO) omits source-set metadata from CPS output. Use the authoritative Config.cmake export or move source-only targets to a non-CPS export.")
+            "CPS package metadata for export '${ARG_EXPORT_NAME}' does not support SOURCES file sets. CMake 4.4.2 install(PACKAGE_INFO) omits source-set metadata from CPS output. Use the authoritative Config.cmake export or move source-only targets to a non-CPS export."
+          )
         endif()
         foreach(CURRENT_SOURCE_SET_NAME IN LISTS TARGET_INTERFACE_SOURCE_SETS)
           list(
@@ -2445,7 +2544,8 @@ function(finalize_package)
   endif()
 
   # Validate template contains required placeholders for provided parameters
-  _validate_config_template_placeholders("${CONFIG_TEMPLATE_TO_USE}" "${ARG_EXPORT_NAME}" "${INCLUDE_ON_FIND_PACKAGE}" "${_tip_package_public_content_required}" "${_tip_find_package_components}")
+  _validate_config_template_placeholders("${CONFIG_TEMPLATE_TO_USE}" "${ARG_EXPORT_NAME}" "${INCLUDE_ON_FIND_PACKAGE}" "${_tip_package_public_content_required}" "${_tip_find_package_components}"
+                                         "${PACKAGE_SOURCE_FILE_SET_PROPERTIES_CONTENT}")
 
   # Generate correct config filename following CMake conventions Use <PackageName>Config.cmake format (exact case + "Config.cmake")
   set(CONFIG_FILENAME "${ARG_EXPORT_NAME}Config.cmake")
@@ -2570,7 +2670,14 @@ function(_auto_finalize_single_export EXPORT_NAME)
 endfunction()
 
 # Template validation helper function
-function(_validate_config_template_placeholders template_path export_name include_files public_deps component_deps)
+function(
+  _validate_config_template_placeholders
+  template_path
+  export_name
+  include_files
+  public_deps
+  component_deps
+  source_file_set_properties)
   # Read template content to validate required placeholders exist
   if(NOT EXISTS "${template_path}")
     project_log(FATAL_ERROR "Template file does not exist: ${template_path}")
@@ -2598,6 +2705,10 @@ function(_validate_config_template_placeholders template_path export_name includ
 
   if(component_deps AND NOT template_content MATCHES "@PACKAGE_COMPONENT_DEPENDENCIES_CONTENT@")
     list(APPEND missing_placeholders "@PACKAGE_COMPONENT_DEPENDENCIES_CONTENT@")
+  endif()
+
+  if(source_file_set_properties AND NOT template_content MATCHES "@PACKAGE_SOURCE_FILE_SET_PROPERTIES_CONTENT@")
+    list(APPEND missing_placeholders "@PACKAGE_SOURCE_FILE_SET_PROPERTIES_CONTENT@")
   endif()
 
   # Report missing placeholders with actionable error message

--- a/tests/cmake/proof_source_file_sets_failures_test.cmake
+++ b/tests/cmake/proof_source_file_sets_failures_test.cmake
@@ -112,4 +112,38 @@ _tip_proof_expect_failure(
   EXPECT_CONTAINS
   "does not support SOURCES file sets")
 
+function(_tip_write_source_file_set_hygiene_fixture name expected_message)
+  set(_tip_fixture_dir "${_tip_case_root}/${name}")
+  file(MAKE_DIRECTORY "${_tip_fixture_dir}/include/proof" "${_tip_fixture_dir}/src")
+  file(WRITE "${_tip_fixture_dir}/include/proof/source.hpp" "#pragma once\n")
+  file(WRITE "${_tip_fixture_dir}/src/source.cpp" "int source_value() { return 42; }\n")
+  string(JOIN " " _tip_source_file_set_properties ${ARGN})
+  file(
+    WRITE "${_tip_fixture_dir}/CMakeLists.txt"
+    "cmake_minimum_required(VERSION 4.4)\n"
+    "project(proof_source_file_set_hygiene_failure VERSION 1.0.0 LANGUAGES CXX)\n"
+    "set(TARGET_INSTALL_PACKAGE_DISABLE_INSTALL ON)\n"
+    "include(\"${TIP_REPO_ROOT}/cmake/load_target_install_package.cmake\")\n"
+    "add_library(source_only INTERFACE)\n"
+    "target_sources(source_only INTERFACE FILE_SET api TYPE HEADERS BASE_DIRS \"\${CMAKE_CURRENT_SOURCE_DIR}/include\" FILES \"\${CMAKE_CURRENT_SOURCE_DIR}/include/proof/source.hpp\")\n"
+    "target_sources(source_only INTERFACE FILE_SET implementation TYPE SOURCES BASE_DIRS \"\${CMAKE_CURRENT_SOURCE_DIR}/src\" FILES \"\${CMAKE_CURRENT_SOURCE_DIR}/src/source.cpp\")\n"
+    "target_install_package(source_only EXPORT_NAME ${name} SOURCE_FILE_SET_PROPERTIES ${_tip_source_file_set_properties})\n")
+  _tip_proof_expect_failure(
+    NAME
+    "${name}-configure"
+    COMMAND
+    "${CMAKE_COMMAND}"
+    -S
+    "${_tip_fixture_dir}"
+    -B
+    "${_tip_fixture_dir}/build"
+    ${_tip_toolchain_args}
+    EXPECT_CONTAINS
+    "${expected_message}")
+endfunction()
+
+_tip_write_source_file_set_hygiene_fixture(malformed-source-file-set-properties "SOURCE_FILE_SET_PROPERTIES for target 'source_only'" implementation SKIP_LINTING)
+_tip_write_source_file_set_hygiene_fixture(unknown-source-file-set-property "UNKNOWN_PROPERTY" implementation UNKNOWN_PROPERTY ON)
+_tip_write_source_file_set_hygiene_fixture(header-source-file-set-property "SOURCE_FILE_SET_PROPERTIES file set 'api'" api SKIP_LINTING ON)
+
 message(STATUS "[proof] CMake 4.4 source file set failure proof passed.")

--- a/tests/cmake/proof_source_file_sets_test.cmake
+++ b/tests/cmake/proof_source_file_sets_test.cmake
@@ -35,10 +35,7 @@ file(
   "target_sources(source_only INTERFACE FILE_SET implementation TYPE SOURCES BASE_DIRS \"\${CMAKE_CURRENT_SOURCE_DIR}/src\" FILES \"\${CMAKE_CURRENT_SOURCE_DIR}/src/source.cpp\")\n"
   "set(GENERATED_VALUE 2)\n"
   "target_configure_sources(source_only INTERFACE TYPE SOURCES FILE_SET generated_implementation OUTPUT_DIR \"\${CMAKE_CURRENT_BINARY_DIR}/generated\" BASE_DIRS \"\${CMAKE_CURRENT_BINARY_DIR}/generated\" FILES src/generated.cpp.in)\n"
-  "set_property(FILE_SET implementation TARGET source_only PROPERTY SKIP_LINTING ON)\n"
-  "set_property(FILE_SET implementation TARGET source_only PROPERTY SKIP_PRECOMPILE_HEADERS ON)\n"
-  "set_property(FILE_SET implementation TARGET source_only PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)\n"
-  "target_install_package(source_only EXPORT_NAME proof_source_pkg NAMESPACE proof:: VERSION 1.0.0)\n"
+  "target_install_package(source_only EXPORT_NAME proof_source_pkg NAMESPACE proof:: VERSION 1.0.0 SOURCE_FILE_SET_PROPERTIES implementation SKIP_LINTING ON implementation SKIP_PRECOMPILE_HEADERS ON generated_implementation SKIP_UNITY_BUILD_INCLUSION ON generated_implementation CXX_SCAN_FOR_MODULES OFF)\n"
   "add_library(custom_source_only INTERFACE)\n"
   "target_sources(custom_source_only INTERFACE FILE_SET implementation TYPE SOURCES BASE_DIRS \"\${CMAKE_CURRENT_SOURCE_DIR}/custom\" FILES \"\${CMAKE_CURRENT_SOURCE_DIR}/custom/custom.cpp\")\n"
   "target_install_package(custom_source_only EXPORT_NAME custom_source_pkg SOURCE_DESTINATION share/custom-source VERSION 1.0.0)\n")
@@ -89,6 +86,13 @@ file(
   "    endif()\n"
   "  endforeach()\n"
   "endforeach()\n"
+  "get_property(skip_lint FILE_SET implementation TARGET proof::source_only PROPERTY SKIP_LINTING)\n"
+  "get_property(skip_pch FILE_SET implementation TARGET proof::source_only PROPERTY SKIP_PRECOMPILE_HEADERS)\n"
+  "get_property(skip_unity FILE_SET generated_implementation TARGET proof::source_only PROPERTY SKIP_UNITY_BUILD_INCLUSION)\n"
+  "get_property(scan_modules FILE_SET generated_implementation TARGET proof::source_only PROPERTY CXX_SCAN_FOR_MODULES)\n"
+  "if(NOT skip_lint OR NOT skip_pch OR NOT skip_unity OR NOT scan_modules STREQUAL \"OFF\")\n"
+  "  message(FATAL_ERROR \"Imported source file-set hygiene properties were not preserved\")\n"
+  "endif()\n"
   "add_executable(proof_source_consumer main.cpp)\n"
   "target_link_libraries(proof_source_consumer PRIVATE proof::source_only)\n")
 file(WRITE "${_tip_consumer_source_dir}/main.cpp" "#include <proof/source.hpp>\nint main() { return source_value() + generated_value() == 42 ? 0 : 1; }\n")


### PR DESCRIPTION
Closes #75

Adds validated file-set-scoped controls for linting, precompiled headers, unity builds, and module scanning. Generated Config.cmake reapplies them to imported source sets.

Validation:
- CMake 4.4.2 configure/build
- ctest: 43/43 passed