### PR TITLE
chore(release): prepare v7.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 project(
   target_install_package
-  VERSION 7.1.0
+  VERSION 7.2.0
   DESCRIPTION "CMake utilities for creating installable packages"
   HOMEPAGE_URL "https://github.com/jkammerland/target_install_package.cmake")
 set(target_install_package_SPDX_LICENSE "MIT")

--- a/CPack-Tutorial.md
+++ b/CPack-Tutorial.md
@@ -217,7 +217,7 @@ cmake_minimum_required(VERSION 3.25)
 project(MyProject VERSION 1.2.0 DESCRIPTION "My awesome library package")
 
 # Include target_install_package() and export_cpack()
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.1.0 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.2.0 CONFIG REQUIRED)
 
 # Create targets (same as before)
 add_library(mylib SHARED src/mylib.cpp)
@@ -542,7 +542,7 @@ GPG_KEYSERVER "keys.corp.internal"
 cmake_minimum_required(VERSION 3.25)
 project(SecureLibrary VERSION 2.1.0)
 
-include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.1.0 CONFIG REQUIRED)
+include(cmake/load_target_install_package.cmake)  # or find_package(target_install_package 7.2.0 CONFIG REQUIRED)
 
 # Create library targets
 add_library(secure_core SHARED src/core.cpp)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ include(FetchContent)
 FetchContent_Declare(
   target_install_package
   GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-  GIT_TAG v7.1.0
+  GIT_TAG v7.2.0
 )
 FetchContent_MakeAvailable(target_install_package)
 
@@ -207,7 +207,7 @@ if(${PROJECT_NAME}_INSTALL)
   FetchContent_Declare(
     target_install_package
     GIT_REPOSITORY https://github.com/jkammerland/target_install_package.cmake.git
-    GIT_TAG v7.1.0
+    GIT_TAG v7.2.0
     # Optional arg to first try find_package locally before fetching, see manual installation
     # NOTE: This must be called last, with 0 to N args following FIND_PACKAGE_ARGS
     # FIND_PACKAGE_ARGS

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -56,7 +56,7 @@ graph TD
 - CPack: `bash ci/run.sh cpack --suite regression`
 - Latest-feature preset: `cmake -S . --presets-file cmake/presets/CMakePresets-4.4.json --preset ci-modern -Werror=install-absolute-destination`
 - Self-release package dry run: `bash ci/run.sh bootstrap --cmake-version 4.4.2 --ninja --gpg && bash ci/run.sh cpack --suite self-release`
-- Release tag verification: `bash ci/run.sh release verify-tag --tag v7.1.0 --trusted-ref refs/remotes/origin/master`
+- Release tag verification: `bash ci/run.sh release verify-tag --tag v7.2.0 --trusted-ref refs/remotes/origin/master`
 
 ## Tagged releases
 

--- a/docs/releases/v7.2.0.md
+++ b/docs/releases/v7.2.0.md
@@ -1,0 +1,21 @@
+# target_install_package v7.2.0
+
+This release completes the CMake 4.4 source-package workflow, from migrating ordinary interface sources to compiling installed sources in consumer-local libraries.
+
+## Highlights
+
+- Adds `SOURCE_FILE_SET_FROM_TARGET_SOURCES` to migrate ordinary sources on interface libraries into relocatable `SOURCES` file sets.
+- Adds `SOURCE_LIBRARY_TYPE` and `SOURCE_LIBRARY_ALIAS` for opt-in consumer-local `STATIC`, `SHARED`, `OBJECT`, or `AUTO` libraries built from installed source file sets.
+- Adds `SOURCE_FILE_SET_PROPERTIES` controls for linting, precompiled headers, unity builds, and C++ module scanning on packaged sources.
+- Adds a relocated hybrid source/prebuilt SDK example and CMake File API structural tests for installed targets, dependency edges, headers, sources, and module file sets.
+- Adds a clean-build reproducibility proof for CMake and CPack 4.4.2 `TGZ` archives under a fixed `SOURCE_DATE_EPOCH`.
+
+## Compatibility
+
+- The core package-install path remains compatible with CMake 3.25.
+- Source file sets, source extraction, consumer-local source libraries, and source file-set properties require CMake 4.4 or newer for both producers and consumers.
+- CPS output remains unavailable for source packages because CMake 4.4.2 omits source-file-set metadata from generated CPS files.
+- The archive reproducibility proof covers CPack 4.4.2 `TGZ` output; other generators and filesystem-specific metadata remain outside that guarantee.
+- The new CMake version policy keeps newer capabilities feature-gated and requires a deprecation cycle before the global minimum can increase in a future major release.
+
+Release CI continues to exercise the CMake 3.25 core floor and the independently gated CMake 3.28, 4.2, 4.3, and 4.4 feature boundaries.

--- a/export_cpack.cmake
+++ b/export_cpack.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.1.0)
+  list_file_include_guard(VERSION 7.2.0)
 else()
   if(COMMAND project_log)
     project_log(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")

--- a/target_configure_sources.cmake
+++ b/target_configure_sources.cmake
@@ -3,7 +3,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.1.0)
+  list_file_include_guard(VERSION 7.2.0)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 

--- a/target_install_package.cmake
+++ b/target_install_package.cmake
@@ -5,7 +5,7 @@ get_property(
   PROPERTY "list_file_include_guard_cmake_INITIALIZED"
   SET)
 if(_LFG_INITIALIZED)
-  list_file_include_guard(VERSION 7.1.0)
+  list_file_include_guard(VERSION 7.2.0)
 else()
   message(VERBOSE "including <${CMAKE_CURRENT_FUNCTION_LIST_FILE}>, without list_file_include_guard")
 


### PR DESCRIPTION
## Summary

- Bump project and module versions to 7.2.0.
- Update pinned usage examples.
- Add curated v7.2.0 release notes.

Includes #71, #72, #73, #74, #75, #76, #77, and #86.

## Validation

- CMake 4.3.1: 41/41 tests; install passed.
- CMake 4.4.2: 49/49 tests; install and consumer passed.
- Self-release TGZ, ZIP, SBOM, signatures, checksums, and packaged consumer passed.